### PR TITLE
bug fix when number of items below max rows and fix when going back more than 2 level of sub menus

### DIFF
--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -51,17 +51,14 @@ class LcdMenu {
      * Cursor position
      */
     uint8_t cursorPosition = 1;
-    uint8_t previousCursorPosition = 1;
     /**
      * First visible item's position in the menu array
      */
     uint8_t top = 1;
-    uint8_t previousTop = 1;
     /**
      * Last visible item's position in the menu array
      */
     uint8_t bottom = 0;
-    uint8_t previousBottom = 0;
     /**
      * Rows on the LCD Display
      */
@@ -189,11 +186,15 @@ class LcdMenu {
                 default:
                     break;
             }
+
+            // if we reached the end of menu, stop
+            if (currentMenuTable[i].getType() == MENU_ITEM_END_OF_MENU)
+                break;
         }
         //
         // determine if cursor is at the top
         //
-        if (top == 1) {
+        if (top == 1 && !isAtTheEnd()) {
             //
             // Print the down arrow only
             //
@@ -243,26 +244,13 @@ class LcdMenu {
         drawMenu();
         drawCursor();
     }
-    /**
-     * Reset the display
-     * @param isHistoryAvailable indicates if there is a previous position
-     */
-    void reset(boolean isHistoryAvailable) {
-        if (isHistoryAvailable) {
-            cursorPosition = previousCursorPosition;
-            top = previousTop;
-            bottom = previousBottom;
-        } else {
-            previousCursorPosition = cursorPosition;
-            previousTop = top;
-            previousBottom = bottom;
-
-            cursorPosition = 1;
-            top = 1;
-            bottom = maxRows;
-        }
-        paint();
+      
+    void setMenuPosition(uint8_t newCursorPosition, uint8_t newTop) {
+        cursorPosition = newCursorPosition;
+        top = newTop;
+        bottom = newTop + maxRows - 1;
     }
+    
     /**
      * Calculate and set the new blinker position
      */
@@ -418,10 +406,14 @@ class LcdMenu {
                 //
                 if (item->getSubMenu() == NULL) return;
                 currentMenuTable = item->getSubMenu();
+                // save the previous position in current menu header
+                currentMenuTable[0].saveParentMenuPosition(cursorPosition, top);
+                // reset menu position to top
+                setMenuPosition(1, 1);
                 //
                 // display the sub menu
                 //
-                reset(false);
+                paint();
                 break;
             }
             //
@@ -486,8 +478,13 @@ class LcdMenu {
         // check if this is a sub menu, if so go back to its parent
         //
         if (menuItemType == MENU_ITEM_SUB_MENU_HEADER) {
+
+            // restore position before we go back to parent menu
+            setMenuPosition(currentMenuTable[0].getParentMenuCursorPosition(), currentMenuTable[0].getParentMenuTop());
+
             currentMenuTable = currentMenuTable[0].getSubMenu();
-            reset(true);
+
+            paint();
         }
     }
     /**

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -56,6 +56,10 @@ class MenuItem {
     fptrInt callbackInt = NULL;
     fptrStr callbackStr = NULL;
     MenuItem* subMenu = NULL;
+    // track parent menu position
+    uint8_t previousMenuCursorPosition = 0;
+    uint8_t previousMenuTop = 0;
+        
     byte type = MENU_ITEM_NONE;
     String* items = NULL;
 
@@ -176,6 +180,20 @@ class MenuItem {
      */
     void setSubMenu(MenuItem* subMenu) { this->subMenu = subMenu; }
 
+    void saveParentMenuPosition(uint8_t cursorPosition, uint8_t top) { 
+        this->previousMenuCursorPosition = cursorPosition; 
+        this->previousMenuTop = top; 
+    }
+    
+    uint8_t getParentMenuCursorPosition() {
+        return this->previousMenuCursorPosition;
+    }
+
+    uint8_t getParentMenuTop() {
+        return this->previousMenuTop;
+    }
+    
+    
     /**
      * Operators
      */


### PR DESCRIPTION
Since some of the bug fixes are only one line, I thought it would be simpler to just commit all 3 fixes in 1 PR. Let me know if you prefer I'll separate it.

First 2 are related to having less menu items than rows. 3rd one was a bit more complicated:

1. If number of menu items was below maxRows, the system would continue to draw the lines all the way to maxRows.
The fix:  In the loop of writing lines, exit when reached the last menu item 

2. If number of menu items was below maxRows, the up icon wasn't displayed when it was supposed to.

3. If you have more than 1 sub menu, only last sub menu position was saved and going back more to upper menu jumped outside of the existing menu items.
The fix:
1. When going into a sub menu, save the current position in the sub menu before reset to the top of the menu.
2. When going back to previous menu, get the saved position , move to previous menu and restore position.