### PR TITLE
Bug fix: displaying menu items that doesn't exists when number of items below lcd maxRows

### DIFF
--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -189,6 +189,10 @@ class LcdMenu {
                 default:
                     break;
             }
+
+            // if we reached the end of menu, stop
+            if (currentMenuTable[i].getType() == MENU_ITEM_END_OF_MENU)
+                break;
         }
         //
         // determine if cursor is at the top


### PR DESCRIPTION
bug fix: if number of menu items was below maxRows, the system would continue to draw the lines all the way to maxRows.

The fix: In the loop of writing lines, exit when reached the last menu item.