### PR TITLE
Bug fix: not displaying up arrow when reaching the last menu item 

### DIFF
--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -193,7 +193,7 @@ class LcdMenu {
         //
         // determine if cursor is at the top
         //
-        if (top == 1) {
+        if (top == 1 && !isAtTheEnd()) {
             //
             // Print the down arrow only
             //


### PR DESCRIPTION
If number of menu items was below maxRows, the up icon wasn't displayed when it was supposed to.