### PR TITLE
Memory-optimization

### DIFF
--- a/diagram.json
+++ b/diagram.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "author": "Uri Shaked",
+  "editor": "wokwi",
+  "parts": [
+    {
+      "type": "wokwi-arduino-uno",
+      "id": "uno",
+      "top": 200,
+      "left": 20,
+      "attrs": {}
+    },
+    {
+      "type": "wokwi-membrane-keypad",
+      "id": "keypad",
+      "top": 19.86,
+      "left": 334.39,
+      "attrs": {
+        "columns": "3",
+        "keys": [
+          "",
+          "🡩",
+          "",
+          "+",
+          "🡨",
+          "•",
+          "🡪",
+          "-",
+          "",
+          "🡫",
+          "",
+          "*",
+          "↩",
+          "0",
+          "✕",
+          "/"
+        ]
+      }
+    },
+    {
+      "type": "wokwi-lcd1602",
+      "id": "lcd1",
+      "top": 20.06,
+      "left": 19.11,
+      "attrs": { "pins": "i2c" }
+    }
+  ],
+  "connections": [
+    ["uno:A3", "keypad:C1", "brown", ["v36.94", "h192.89"]],
+    ["uno:A2", "keypad:C2", "gray", ["v47.76", "h211.89"]],
+    ["uno:A1", "keypad:C3", "orange", ["v59.27", "h230.89"]],
+    ["uno:A0", "keypad:C4", "pink", ["v88", "*", "h0", "v0"]],
+    ["uno:5", "keypad:R1", "blue", ["v-34", "h96", "*", "v12"]],
+    ["uno:4", "keypad:R2", "green", ["v-30", "h80", "*", "v16"]],
+    ["uno:3", "keypad:R3", "purple", ["v-26", "h64", "*", "v20"]],
+    ["uno:2", "keypad:R4", "gold", ["v-22", "h48", "v229.85", "h135.14"]],
+    ["lcd1:SDA", "uno:A4", "blue", ["h-30.42", "v369.27", "h273.31"]],
+    ["lcd1:SCL", "uno:A5", "limegreen", ["h-16.48", "v370.62", "h268.87"]],
+    ["lcd1:VCC", "uno:5V", "red", ["h-42.82", "v366.38", "h199.71"]],
+    ["lcd1:GND", "uno:GND.1", "black", ["h-24.23", "v175.22"]]
+  ],
+  "dependencies": {}
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -24,11 +24,11 @@ drawCursor	KEYWORD2
 drawMenu	KEYWORD2
 isAtTheStart	KEYWORD2
 isAtTheEnd	KEYWORD2
-paint	KEYWORD2
 reset	KEYWORD2
 resetBlinker	KEYWORD2
 setupLcdWithMenu	KEYWORD2
 setSubMenu	KEYWORD2
+update	KEYWORD2
 up	KEYWORD2
 down	KEYWORD2
 enter	KEYWORD2

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,3 +14,4 @@ board = uno
 framework = arduino
 lib_deps = 
 	marcoschwartz/LiquidCrystal_I2C@^1.1.4
+	chris--a/Keypad@^3.1.1

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -1,0 +1,21 @@
+#include <Arduino.h>
+
+#ifndef MenuConstants_H
+#define MenuConstants_H
+
+typedef void (*fptr)();
+typedef void (*fptrInt)(uint8_t);
+//
+// menu item types
+//
+#define MENU_ITEM_MAIN_MENU_HEADER 1
+#define MENU_ITEM_SUB_MENU_HEADER 2
+#define MENU_ITEM_SUB_MENU 3
+#define MENU_ITEM_COMMAND 4
+#define MENU_ITEM_INPUT 5
+#define MENU_ITEM_NONE 6
+#define MENU_ITEM_TOGGLE 7
+#define MENU_ITEM_END_OF_MENU 8
+#define MENU_ITEM_LIST 9
+
+#endif

--- a/src/ItemCommand.h
+++ b/src/ItemCommand.h
@@ -1,0 +1,28 @@
+#ifndef ItemCommand_H
+#define ItemCommand_H
+
+#ifndef MenuConstants_H
+#include <Constants.h>
+#endif
+
+/**
+ * ---
+ *
+ * # ItemCommand
+ *
+ * This item type indicates that the current item is a **command**.
+ * When `enter()` is invoked, the command *(callback)* bound to this item is
+ * invoked.
+ */
+
+class ItemCommand : public MenuItem {
+   public:
+    /**
+     * @param key key of the item
+     * @param callback reference to callback function
+     */
+    ItemCommand(const char* key, fptr callback)
+        : MenuItem(key, callback, MENU_ITEM_COMMAND) {}
+};
+
+#endif

--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -712,17 +712,6 @@ class LcdMenu {
      */
     uint8_t getCursorPosition() { return this->cursorPosition; }
     /**
-     * @brief Execute a callback after [delay] milliseconds
-     *
-     * @param callback The callback to be executed
-     * @param delay Deley time in milliseconds
-     */
-    void run(fptr callback, uint8_t delay) {
-        this->delay = delay;
-        this->startTime = millis();
-        if (millis() == startTime + delay) fptr();
-    }
-    /**
      * Show a message at the bottom of the screen
      * @param message message to display
      * @param duration how long to display the message

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -52,7 +52,9 @@ class MenuItem {
     const char* text = NULL;
     const char* textOn = NULL;
     const char* textOff = NULL;
+#ifdef ItemCommand_H
     fptr callback = NULL;
+#endif
     fptrInt callbackInt = NULL;
     fptrStr callbackStr = NULL;
     MenuItem* subMenu = NULL;
@@ -68,6 +70,7 @@ class MenuItem {
      * `Boolean` state of the item *(either ON or OFF)*
      */
     boolean isOn = false;
+#ifdef ItemInput_H
     /**
      * String value of an `ItemInput`
      */
@@ -83,10 +86,10 @@ class MenuItem {
 
     MenuItem() = default;
     explicit MenuItem(const char* text) : text(text) {}
+#ifdef ItemCommand_H
     MenuItem(const char* text, fptr callback, byte type)
         : text(text), callback(callback), type(type) {}
-    MenuItem(const char* text, fptr callback, MenuItem* subMenu, byte type)
-        : text(text), callback(callback), subMenu(subMenu), type(type) {}
+#endif
     MenuItem(MenuItem* subMenu, byte type) : subMenu(subMenu), type(type) {}
     MenuItem(const char* text, MenuItem* subMenu, byte type)
         : text(text), subMenu(subMenu), type(type) {}
@@ -115,11 +118,13 @@ class MenuItem {
      * @return `String` - Item's text
      */
     const char* getText() { return text; }
+#ifdef ItemCommand_H
     /**
      * Get the callback of the item
      * @return `ftpr` - Item's callback
      */
     fptr getCallback() { return callback; }
+#endif
     /**
      * Get the callback of the item
      * @return `fptrInt` - Item's callback
@@ -165,11 +170,13 @@ class MenuItem {
      * @param text text to display for the item
      */
     void setText(const char* text) { this->text = text; }
+#ifdef ItemCommand_H
     /**
      * Set the callback on the item
      * @param callback reference to callback function
      */
     void setCallBack(fptr callback) { this->callback = callback; }
+#endif
     /**
      * Set the sub menu on the item
      * @param subMenu for the item
@@ -311,26 +318,6 @@ class ItemToggle : public MenuItem {
      */
     ItemToggle(const char* key, char* textOn, char* textOff, fptrInt callback)
         : MenuItem(key, textOn, textOff, callback, MENU_ITEM_TOGGLE) {}
-};
-
-/**
- * ---
- *
- * # ItemCommand
- *
- * This item type indicates that the current item is a **command**.
- * When `enter()` is invoked, the command *(callback)* bound to this item is
- * invoked.
- */
-
-class ItemCommand : public MenuItem {
-   public:
-    /**
-     * @param key key of the item
-     * @param callback reference to callback function
-     */
-    ItemCommand(const char* key, fptr callback)
-        : MenuItem(key, callback, MENU_ITEM_COMMAND) {}
 };
 
 /**

--- a/wokwi.toml
+++ b/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version=1
+firmware='.pio\build\uno\firmware.hex'
+elf='.pio\build\uno\firmware.elf'


### PR DESCRIPTION
The current implementation of the menu uses a lot of memory since space has to be reserved for every field on the menu even if it is not used, this PR will fix that by allowing the user to import only MenuItems which is needed by the user. #62 