### PR TITLE
Memory optimization

### DIFF
--- a/.scripts/keywords.py
+++ b/.scripts/keywords.py
@@ -1,7 +1,8 @@
 import re
+
 import click
 
-prefixes = [':', '*', '}', '/', '#', 'for ', 'if ', 'switch ', 'case ', 'return ', 'class ', 'explicit ']
+prefixes = [':', '*', '}', '/', '#', 'for ', 'if ', 'switch ', 'case ', 'return ', 'class ', 'explicit ', 'virtual ']
 sufixes = [';', '-', '=', ',', '*', '.', '= {', '{}']
 
 pre_key_1 = """#######################################
@@ -41,7 +42,7 @@ def build(files):
             for line in a_file:
                 stripped_line = line.strip()
 
-                if len(stripped_line) > 9 and not stripped_line.startswith(tuple(prefixes)) and not stripped_line.endswith(tuple(sufixes)):
+                if len(stripped_line) > 9 and (not stripped_line.startswith(tuple(prefixes)) and not stripped_line.endswith(tuple(sufixes))):
                     if re.search(r"^.+\s[a-z][A-Za-z]+\(.*", stripped_line) != None:
                         words = re.findall(r"\w+", stripped_line)
                         methodName = words[1]
@@ -52,7 +53,7 @@ def build(files):
                     if re.search(r"\w+", stripped_line) != None:
                         methodName = re.findall(r"\w+", stripped_line)[1]
                         keyword_1_data += methodName + "	KEYWORD1\n"
-                if len(stripped_line) > 7 and stripped_line.startswith('#ifndef') and not stripped_line.endswith('_H'):
+                if len(stripped_line) > 7 and (stripped_line.startswith('#ifndef') or stripped_line.startswith('#define')) and not stripped_line.endswith('_H'):
                     if re.search(r"\w+", stripped_line) != None:
                         methodName = re.findall(r"\w+", stripped_line)[1]
                         if re.search(methodName, literal_1_data) == None:

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ LcdMenu is an Arduino library that enables you to create interactive menus and n
 
 ## Installation
 
-#### with Arduino Library Manager
+#### With Arduino Library Manager
 
 Follow this 👇 guide to install the library
 
 [![arduino-library-badge](https://www.ardu-badge.com/badge/LcdMenu.svg?)](https://www.ardu-badge.com/LcdMenu)
 
-#### with PlatformIO
+#### With PlatformIO
 
 1. Open the PlatformIO IDE or VSCode with PlatformIO extension installed.
 1. Create a new project or open an existing one.
@@ -87,7 +87,7 @@ The most essential actions are:
 - `menu.up()` and `menu.down()` - Go up and down the menu
 - `menu.left()` and `menu.right()` - if the menu is in edit mode,
   - for `ITEM_INPUT` it moves along the characters of the value.
-  - for `ITEM_LIST` it cycles through the items.
+  - for `ITEM_STRING_LIST` it cycles through the items.
 - `menu.enter()` - if the active item is
   - `ITEM_INPUT` or `ITEM_LIST` it goes into edit mode, if you call it again while in edit mode, it executes the callback bound to the item and exits edit mode.
   - `ITEM_COMAND` or `ITEM_TOGGLE` it executes the bound callback

--- a/README.md
+++ b/README.md
@@ -15,13 +15,7 @@ LcdMenu is an Arduino library that enables you to create interactive menus and n
 
 ## Installation
 
-#### With Arduino Library Manager
-
-Follow this 👇 guide to install the library
-
-[![arduino-library-badge](https://www.ardu-badge.com/badge/LcdMenu.svg?)](https://www.ardu-badge.com/LcdMenu)
-
-#### With PlatformIO
+Follow [this guide](https://www.ardu-badge.com/LcdMenu) to install the library with **Arduino Library Manager** or install it with **PlatformIO** using the steps below:
 
 1. Open the PlatformIO IDE or VSCode with PlatformIO extension installed.
 1. Create a new project or open an existing one.
@@ -46,9 +40,9 @@ To use the LcdMenu library in your project, follow these steps:
 #include <LcdMenu.h>
 ```
 
-You also might need to add other includes for the types of menu items you wish to use e.g `#include <ItemCommand.h>`, the available types are described in the following step.
+You will need to add other includes for the types of menu items you wish to use, the available types are described in the next step.
 
-#### 2. Create the main menu, use the provided macro `MAIN_MENU()` e.g
+#### 2. Create the main menu, use the provided macro `MAIN_MENU()` e.g.
 
 ```js
 MAIN_MENU(
@@ -61,24 +55,26 @@ MAIN_MENU(
 
 Replace the sample menu items with your own menu items. Here are the different types of menu items available:
 
-- `ITEM_BASIC` - a basic menu item with no functionality
-- `ITEM_COMMAND` - a menu item that executes a function when selected
-- `ITEM_TOGGLE` - a menu item that toggles a value when selected
-- `ITEM_INPUT` - a menu item that prompts the user to enter a value
-- `ITEM_SUBMENU` - a menu item that leads to a sub-menu when selected
-- `ITEM_LIST` - a menu item that displays value that is chosen form a list
+| Type               | Description                                                                 | Import            |
+| ------------------ | --------------------------------------------------------------------------- | ----------------- |
+| `ITEM_BASIC`       | a basic menu item with **no functionality**                                 | N/A               |
+| `ITEM_COMMAND`     | a menu item that **executes** a function when selected                      | `<ItemCommand.h>` |
+| `ITEM_TOGGLE`      | a menu item that **toggles** a value when selected                          | `<ItemToggle.h>`  |
+| `ITEM_INPUT`       | a menu item that **prompts** the user to enter a value                      | `<ItemInput.h>`   |
+| `ITEM_SUBMENU`     | a menu item that leads to a **sub-menu** when selected                      | `<ItemSubMenu.h>` |
+| `ITEM_STRING_LIST` | a menu item that displays a value that is chosen form a **list of strings** | `<ItemList.h>`    |
 
 For each menu item, specify the menu item text, and any necessary parameters. For example, in `ITEM_COMMAND("Backlight", toggleBacklight)`, `"Backlight"` is the menu item text and `toggleBacklight` is the function to be executed when the item is selected.
 
-#### 3. In the `setup()` function, initialize your LCD display and set up any necessary pins
-
-#### 4. Once you have created your menu, initialize LcdMenu with the menu items in the `setup()`
+#### 3. Once you have created your menu, initialize LcdMenu with the menu items in the `setup()`
 
 ```cpp
 menu.setupLcdWithMenu(0x27, mainMenu); //I2C
+// or
+menu.setupLcdWithMenu(rs, en, d0, d1, d2, d3, mainMenu); // Standard
 ```
 
-#### 5. In the `loop()` function, define how you want to navigate the menu
+#### 4. In the `loop()` function, define how you want to navigate the menu
 
 You can use any input method of your choice to perform actions on the menu
 
@@ -89,13 +85,15 @@ The most essential actions are:
   - for `ITEM_INPUT` it moves along the characters of the value.
   - for `ITEM_STRING_LIST` it cycles through the items.
 - `menu.enter()` - if the active item is
-  - `ITEM_INPUT` or `ITEM_LIST` it goes into edit mode, if you call it again while in edit mode, it executes the callback bound to the item and exits edit mode.
+  - `ITEM_INPUT` or `ITEM_STRING_LIST` it goes into edit mode, if you call it again while in edit mode, it executes the callback bound to the item and exits edit mode.
   - `ITEM_COMAND` or `ITEM_TOGGLE` it executes the bound callback
   - `ITEM_SUBMENU` it enters the sub-menu.
 - `menu.back()` - either exits edit mode or goes to back to a parent menu depending on the active item.
 
-### And that's it! You should now have a fully functional LCD menu system for your Arduino project
+Full examples can be found [here](https://github.com/forntoh/LcdMenu/tree/master/examples) 👈
 
-More examples [here](https://github.com/forntoh/LcdMenu/tree/master/examples)
+## And that's it! You should now have a fully functional LCD menu system for your Arduino project
+
+---
 
 **Have a question/doubt? Check the [Discussions](https://github.com/forntoh/LcdMenu/discussions) tab, maybe your question has already been answered 😉**

--- a/README.md
+++ b/README.md
@@ -1,28 +1,101 @@
-# LcdMenu
+# LcdMenu 📟
 
 [![arduino-library-badge](https://www.ardu-badge.com/badge/LcdMenu.svg?)](https://www.ardu-badge.com/LcdMenu)
 [![PlatformIO Registry](https://badges.registry.platformio.org/packages/forntoh/library/LcdMenu.svg)](https://registry.platformio.org/libraries/forntoh/LcdMenu)
 
-Display navigable menu items on your LCD display with Arduino
+LcdMenu is an Arduino library that enables you to create interactive menus and navigation systems for LCD displays. With LcdMenu, you can easily add menus to your projects and navigate through them using buttons or any input device you want. The library supports a wide range of LCD display modules, including character and alphanumeric displays.
 
 ![Basic](https://i.imgur.com/nViET8b.gif)
 
 ## Features
 
-- Dynamic menus.
-- Compatible with all Character LCD Display Modules and VATN Alphanumeric LCD Displays.
-- Many menu types available
-- Callback functions.
-- Display timed notifications.
+- Dynamic menus: Create menus with multiple levels and submenus.
+- Multiple menu types: Choose from different menu types such as command, toggle, and input.
+- Callback functions: Assign functions to menu items to execute specific tasks when triggered.
 
 ## Installation
+
+#### with Arduino Library Manager
 
 Follow this 👇 guide to install the library
 
 [![arduino-library-badge](https://www.ardu-badge.com/badge/LcdMenu.svg?)](https://www.ardu-badge.com/LcdMenu)
 
-For Usage & Examples,
+#### with PlatformIO
 
-## Visit the official [Docs](https://forntoh.gitbook.io/lcdmenu/) of this Library
+1. Open the PlatformIO IDE or VSCode with PlatformIO extension installed.
+1. Create a new project or open an existing one.
+1. Add the LcdMenu library to your project by adding the following line to your `platformio.ini` file:
+
+   ```makefile
+   lib_deps =
+       forntoh/LcdMenu@^3.0.0
+   ```
+
+1. Save the changes to the `platformio.ini` file.
+
+1. Build and upload your project to your device.
+
+## Usage
+
+To use the LcdMenu library in your project, follow these steps:
+
+#### 1. Include the LcdMenu library in your sketch
+
+```cpp
+#include <LcdMenu.h>
+```
+
+You also might need to add other includes for the types of menu items you wish to use e.g `#include <ItemCommand.h>`, the available types are described in the following step.
+
+#### 2. Create the main menu, use the provided macro `MAIN_MENU()` e.g
+
+```js
+MAIN_MENU(
+  ITEM_INPUT("Connect", resultCallback),
+  ITEM_BASIC("Settings"),
+  ITEM_COMMAND("Backlight", toggleBacklight),
+  ITEM_TOGGLE("Toggle", "ON", "OFF", toggleStuff)
+);
+```
+
+Replace the sample menu items with your own menu items. Here are the different types of menu items available:
+
+- `ITEM_BASIC` - a basic menu item with no functionality
+- `ITEM_COMMAND` - a menu item that executes a function when selected
+- `ITEM_TOGGLE` - a menu item that toggles a value when selected
+- `ITEM_INPUT` - a menu item that prompts the user to enter a value
+- `ITEM_SUBMENU` - a menu item that leads to a sub-menu when selected
+- `ITEM_LIST` - a menu item that displays value that is chosen form a list
+
+For each menu item, specify the menu item text, and any necessary parameters. For example, in `ITEM_COMMAND("Backlight", toggleBacklight)`, `"Backlight"` is the menu item text and `toggleBacklight` is the function to be executed when the item is selected.
+
+#### 3. In the `setup()` function, initialize your LCD display and set up any necessary pins
+
+#### 4. Once you have created your menu, initialize LcdMenu with the menu items in the `setup()`
+
+```cpp
+menu.setupLcdWithMenu(0x27, mainMenu); //I2C
+```
+
+#### 5. In the `loop()` function, define how you want to navigate the menu
+
+You can use any input method of your choice to perform actions on the menu
+
+The most essential actions are:
+
+- `menu.up()` and `menu.down()` - Go up and down the menu
+- `menu.left()` and `menu.right()` - if the menu is in edit mode,
+  - for `ITEM_INPUT` it moves along the characters of the value.
+  - for `ITEM_LIST` it cycles through the items.
+- `menu.enter()` - if the active item is
+  - `ITEM_INPUT` or `ITEM_LIST` it goes into edit mode, if you call it again while in edit mode, it executes the callback bound to the item and exits edit mode.
+  - `ITEM_COMAND` or `ITEM_TOGGLE` it executes the bound callback
+  - `ITEM_SUBMENU` it enters the sub-menu.
+- `menu.back()` - either exits edit mode or goes to back to a parent menu depending on the active item.
+
+### And that's it! You should now have a fully functional LCD menu system for your Arduino project
+
+More examples [here](https://github.com/forntoh/LcdMenu/tree/master/examples)
 
 **Have a question/doubt? Check the [Discussions](https://github.com/forntoh/LcdMenu/discussions) tab, maybe your question has already been answered 😉**

--- a/diagram.json
+++ b/diagram.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "author": "Uri Shaked",
+  "editor": "wokwi",
+  "parts": [
+    {
+      "type": "wokwi-arduino-uno",
+      "id": "uno",
+      "top": 200,
+      "left": 20,
+      "attrs": {}
+    },
+    {
+      "type": "wokwi-membrane-keypad",
+      "id": "keypad",
+      "top": 19.86,
+      "left": 334.39,
+      "attrs": {
+        "columns": "3",
+        "keys": [
+          "",
+          "↑",
+          "",
+          "+",
+          "←",
+          "•",
+          "→",
+          "-",
+          "",
+          "↓",
+          "",
+          "*",
+          "↩",
+          "0",
+          "✕",
+          "/"
+        ]
+      }
+    },
+    {
+      "type": "wokwi-lcd1602",
+      "id": "lcd1",
+      "top": 20.06,
+      "left": 19.11,
+      "attrs": { "pins": "i2c" }
+    }
+  ],
+  "connections": [
+    ["uno:A3", "keypad:C1", "brown", ["v36.94", "h192.89"]],
+    ["uno:A2", "keypad:C2", "gray", ["v47.76", "h211.89"]],
+    ["uno:A1", "keypad:C3", "orange", ["v59.27", "h230.89"]],
+    ["uno:A0", "keypad:C4", "pink", ["v88", "*", "h0", "v0"]],
+    ["uno:5", "keypad:R1", "blue", ["v-34", "h96", "*", "v12"]],
+    ["uno:4", "keypad:R2", "green", ["v-30", "h80", "*", "v16"]],
+    ["uno:3", "keypad:R3", "purple", ["v-26", "h64", "*", "v20"]],
+    ["uno:2", "keypad:R4", "gold", ["v-22", "h48", "v229.85", "h135.14"]],
+    ["lcd1:SDA", "uno:A4", "blue", ["h-30.42", "v369.27", "h273.31"]],
+    ["lcd1:SCL", "uno:A5", "limegreen", ["h-16.48", "v370.62", "h268.87"]],
+    ["lcd1:VCC", "uno:5V", "red", ["h-42.82", "v366.38", "h199.71"]],
+    ["lcd1:GND", "uno:GND.1", "black", ["h-24.23", "v175.22"]]
+  ],
+  "dependencies": {}
+}

--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -68,10 +68,4 @@ void loop() {
         menu.enter();
     else if (command == BACK)
         menu.back();
-    else if (command == CLEAR)
-        menu.clear();
-    else if (command == BACKSPACE)
-        menu.backspace();
-    else
-        menu.type(command);
 }

--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -32,17 +32,14 @@
 #define BACKSPACE 8  // BACKSPACE
 #define CLEAR 46     // NUMPAD .
 
-// Define the main menu
-extern MenuItem mainMenu[];
-
 // Initialize the main menu items
-MenuItem mainMenu[] = {ItemHeader(),
-                       MenuItem("Start service"),
-                       MenuItem("Connect to WiFi"),
-                       MenuItem("Settings"),
-                       MenuItem("Blink SOS"),
-                       MenuItem("Blink random"),
-                       ItemFooter()};
+MAIN_MENU(
+    ITEM_BASIC("Start service"),
+    ITEM_BASIC("Connect to WiFi"),
+    ITEM_BASIC("Settings"),
+    ITEM_BASIC("Blink SOS"),
+    ITEM_BASIC("Blink random")
+);
 // Construct the LcdMenu
 LcdMenu menu(LCD_ROWS, LCD_COLS);
 

--- a/examples/Basic/README.md
+++ b/examples/Basic/README.md
@@ -14,19 +14,16 @@ This is a basic example, it will show you how to get started with the LcdMenu li
 Go to [.../examples/Basic/Basic.ino](https://github.com/forntoh/LcdMenu/tree/master/examples/Basic/Basic.ino)
 
 ```cpp
-// ../../examples/Basic/Basic.ino#L35-L77
-
-// Define the main menu
-extern MenuItem mainMenu[];
+// ../../examples/Basic/Basic.ino#L35-L68
 
 // Initialize the main menu items
-MenuItem mainMenu[] = {ItemHeader(),
-                       MenuItem("Start service"),
-                       MenuItem("Connect to WiFi"),
-                       MenuItem("Settings"),
-                       MenuItem("Blink SOS"),
-                       MenuItem("Blink random"),
-                       ItemFooter()};
+MAIN_MENU(
+    ITEM_BASIC("Start service"),
+    ITEM_BASIC("Connect to WiFi"),
+    ITEM_BASIC("Settings"),
+    ITEM_BASIC("Blink SOS"),
+    ITEM_BASIC("Blink random")
+);
 // Construct the LcdMenu
 LcdMenu menu(LCD_ROWS, LCD_COLS);
 
@@ -52,11 +49,5 @@ void loop() {
         menu.enter();
     else if (command == BACK)
         menu.back();
-    else if (command == CLEAR)
-        menu.clear();
-    else if (command == BACKSPACE)
-        menu.backspace();
-    else
-        menu.type(command);
 }
 ```

--- a/examples/Callbacks/Callbacks.ino
+++ b/examples/Callbacks/Callbacks.ino
@@ -37,25 +37,14 @@
 // Declare the call back function
 void toggleBacklight(uint8_t isOn);
 
-extern MenuItem mainMenu[];
-extern MenuItem settingsMenu[];
-
-MenuItem mainMenu[] = {ItemHeader(),
-                       MenuItem("Start service"),
-                       MenuItem("Connect to WiFi"),
-                       ItemSubMenu("Settings", settingsMenu),
-                       MenuItem("Blink SOS"),
-                       MenuItem("Blink random"),
-                       ItemFooter()};
-/**
- * Create submenu and precise its parent
- */
-MenuItem settingsMenu[] = {ItemHeader(mainMenu),
-                           //
-                           // Include callback in ItemToggle
-                           //
-                           ItemToggle("Backlight", toggleBacklight),
-                           MenuItem("Contrast"), ItemFooter()};
+// prettier-ignore
+MAIN_MENU(
+    ITEM_BASIC("Start service"),
+    ITEM_BASIC("Connect to WiFi"),
+    ITEM_TOGGLE("Backlight", toggleBacklight),
+    ITEM_BASIC("Blink SOS"),
+    ITEM_BASIC("Blink random")
+);
 
 LcdMenu menu(LCD_ROWS, LCD_COLS);
 

--- a/examples/Callbacks/Callbacks.ino
+++ b/examples/Callbacks/Callbacks.ino
@@ -17,6 +17,8 @@
 
 */
 
+#include <ItemSubMenu.h>
+#include <ItemToggle.h>
 #include <LcdMenu.h>
 
 #define LCD_ROWS 2
@@ -78,12 +80,6 @@ void loop() {
         menu.enter();
     else if (command == BACK)
         menu.back();
-    else if (command == CLEAR)
-        menu.clear();
-    else if (command == BACKSPACE)
-        menu.backspace();
-    else
-        menu.type(command);
 }
 /**
  * Define callback

--- a/examples/Callbacks/README.md
+++ b/examples/Callbacks/README.md
@@ -24,14 +24,16 @@ void toggleBacklight(uint8_t isOn);
 ### 2. Add callback to MenuItem
 
 ```cpp
-// ../../examples/Callbacks/Callbacks.ino#L51-L56
-
-MenuItem settingsMenu[] = {ItemHeader(mainMenu),
-                           //
-                           // Include callback in ItemToggle
-                           //
-                           ItemToggle("Backlight", toggleBacklight),
-                           MenuItem("Contrast"), ItemFooter()};
+MAIN_MENU(
+    ITEM_BASIC("Start service"),
+    ITEM_BASIC("Connect to WiFi"),
+    //
+    // Include callback in ItemToggle
+    //
+    ITEM_TOGGLE("Backlight", toggleBacklight),
+    ITEM_BASIC("Blink SOS"),
+    ITEM_BASIC("Blink random")
+);
 ```
 
 ### 3. Define the callback function
@@ -39,8 +41,6 @@ MenuItem settingsMenu[] = {ItemHeader(mainMenu),
 When `enter()` is invoked, the command _(callback)_ bound to the item is invoked.
 
 ```cpp
-// ../../examples/Callbacks/Callbacks.ino#L88-L95
-
 /**
  * Define callback
  */

--- a/examples/CharsetInput/CharsetInput.ino
+++ b/examples/CharsetInput/CharsetInput.ino
@@ -43,14 +43,12 @@ uint8_t charsetPosition;
 // Declare the call back function
 void inputCallback(String value);
 
-extern MenuItem mainMenu[];
-
-MenuItem mainMenu[] = {ItemHeader(),
-                       ItemInput("Con", inputCallback),
-                       MenuItem("Connect to WiFi"),
-                       MenuItem("Blink SOS"),
-                       MenuItem("Blink random"),
-                       ItemFooter()};
+MAIN_MENU(
+    ITEM_INPUT("Con", inputCallback),
+    ITEM_BASIC("Connect to WiFi"),
+    ITEM_BASIC("Blink SOS"),
+    ITEM_BASIC("Blink random")
+);
 
 LcdMenu menu(LCD_ROWS, LCD_COLS);
 

--- a/examples/CharsetInput/CharsetInput.ino
+++ b/examples/CharsetInput/CharsetInput.ino
@@ -18,6 +18,7 @@
 
 */
 
+#include <ItemInput.h>
 #include <LcdMenu.h>
 
 #define LCD_ROWS 2

--- a/examples/CharsetInput/README.md
+++ b/examples/CharsetInput/README.md
@@ -38,8 +38,7 @@ Execute `enter()` to go to edit mode. _(cursor will start blinking 😉)_
 `drawChar(char c)` is used to dispay the character without storing the value, the value will be stored only when `type(char character)` is executed.
 
 ```cpp
-// ../../examples/CharsetInput/CharsetInput.ino#L68-L80
-
+// ...
 case UP:
     if (menu.isInEditMode())  // Update the position only in edit mode
         charsetPosition = (charsetPosition + 1) % CHARSET_SIZE;
@@ -53,6 +52,7 @@ case DOWN:
     menu.drawChar(charset[charsetPosition]);  // Works only in edit mode
     menu.down();
     break;
+// ...
 ```
 
 ### 5. Type the selected character
@@ -60,10 +60,9 @@ case DOWN:
 Use `menu.type(char character)` to type the selected character
 
 ```cpp
-// ../../examples/CharsetInput/CharsetInput.ino#L87-L88
-
 case ENTER:  // Press enter to go to edit mode : for ItemInput
     menu.type(charset[charsetPosition]);  // Works only in edit mode
+    menu.enter();
 ```
 
 ### 6. `menu.back()` will exit edit mode

--- a/examples/List/List.ino
+++ b/examples/List/List.ino
@@ -18,6 +18,7 @@
 
 */
 
+#include <ItemList.h>
 #include <LcdMenu.h>
 
 #define LCD_ROWS 2
@@ -85,12 +86,6 @@ void loop() {
         menu.enter();
     else if (command == BACK)
         menu.back();
-    else if (command == CLEAR)
-        menu.clear();
-    else if (command == BACKSPACE)
-        menu.backspace();
-    else
-        menu.type(command);
 }
 
 // Define the calbacks

--- a/examples/List/List.ino
+++ b/examples/List/List.ino
@@ -51,15 +51,13 @@ String nums[] = {
     "5", "7", "9", "12", "32",
 };
 
-// Declare the main menu
-extern MenuItem mainMenu[];
 // Initialize the main menu items
-MenuItem mainMenu[] = {ItemHeader(),
-                       MenuItem("List demo"),
-                       ItemList("Col", colors, 9, colorsCallback),
-                       ItemList("Num", nums, 5, numsCallback),
-                       MenuItem("Example"),
-                       ItemFooter()};
+MAIN_MENU(
+    ITEM_BASIC("List demo"),
+    ITEM_STRING_LIST("Col", colors, 9, colorsCallback),
+    ITEM_STRING_LIST("Num", nums, 5, numsCallback),
+    ITEM_BASIC("Example")
+);
 
 // Construct the LcdMenu
 LcdMenu menu(LCD_ROWS, LCD_COLS);

--- a/examples/List/README.md
+++ b/examples/List/README.md
@@ -24,20 +24,16 @@ extern String colors[];
 ### 2. Initialize the array
 
 ```cpp
-// ../../examples/List/List.ino#L43-L44
-
 String colors[] = {"Red",  "Green",  "Blue",   "Orange",
                    "Aqua", "Yellow", "Purple", "Pink"};
 ```
 
 ### 3. Add the array to your `MenuItem`
 
-You must add the size of the array in order for the menu to know when to stop or loop when cycling through the items in the list.
+You **must** add the size of the array in order for the menu to know when to stop or loop when cycling through the items in the list.
 
 ```cpp
-// ../../examples/List/List.ino#L58-L58
-
-ItemList("Col", colors, 9, colorsCallback),
+ITEM_STRING_LIST("Col", colors, 9, colorsCallback),
 ```
 
 ### 4. Cycle through list
@@ -52,8 +48,6 @@ Use `menu.left()` and/or `menu.right()` to cycle through the items
 When `enter()` is invoked, the command _(callback)_ bound to the item is invoked.
 
 ```cpp
-// ../../examples/List/List.ino#L97-L100
-
 void colorsCallback(uint8_t pos) {
     // do something with the index
     Serial.println(colors[pos]);

--- a/examples/MenuNotifications/MenuNotifications.ino
+++ b/examples/MenuNotifications/MenuNotifications.ino
@@ -76,12 +76,7 @@ void loop() {
         menu.enter();
     else if (command == BACK)
         menu.back();
-    else if (command == CLEAR)
-        menu.clear();
-    else if (command == BACKSPACE)
-        menu.backspace();
     else {
-        menu.type(command);
         menu.displayNotification("Success", 2000);
     }
 }

--- a/examples/MenuNotifications/MenuNotifications.ino
+++ b/examples/MenuNotifications/MenuNotifications.ino
@@ -37,14 +37,13 @@
 #define BACKSPACE 8  // BACKSPACE
 #define CLEAR 46     // NUMPAD .
 
-extern MenuItem mainMenu[];
-
-MenuItem mainMenu[] = {ItemHeader(),
-                       MenuItem("Start service"),
-                       MenuItem("Connect to WiFi"),
-                       MenuItem("Settings"),
-                       MenuItem("Blink SOS"),
-                       ItemFooter()};
+MAIN_MENU(
+    ITEM_BASIC("Start service"),
+    ITEM_BASIC("Connect to WiFi"),
+    ITEM_BASIC("Settings"),
+    ITEM_BASIC("Blink SOS"),
+    ITEM_BASIC("Blink random")
+);
 
 LcdMenu menu(LCD_ROWS, LCD_COLS);
 

--- a/examples/SimpleInput/README.md
+++ b/examples/SimpleInput/README.md
@@ -16,8 +16,6 @@ This is a basic example, it will show you how to use ItemInput in the LcdMenu li
 Use `menu.type(char character)` to type a character
 
 ```cpp
-// ../../examples/SimpleInput/SimpleInput.ino#L74-L75
-
 else  // Type the character you want
     menu.type(command);
 ```

--- a/examples/SimpleInput/SimpleInput.ino
+++ b/examples/SimpleInput/SimpleInput.ino
@@ -36,14 +36,12 @@
 // Declare the call back function
 void inputCallback(String value);
 
-extern MenuItem mainMenu[];
-
-MenuItem mainMenu[] = {ItemHeader(),
-                       ItemInput("Con", inputCallback),
-                       MenuItem("Connect to WiFi"),
-                       MenuItem("Blink SOS"),
-                       MenuItem("Blink random"),
-                       ItemFooter()};
+MAIN_MENU(
+    ITEM_INPUT("Con", inputCallback), 
+    ITEM_BASIC("Connect to WiFi"),
+    ITEM_BASIC("Blink SOS"), 
+    ITEM_BASIC("Blink random")
+);
 
 LcdMenu menu(LCD_ROWS, LCD_COLS);
 

--- a/examples/SimpleInput/SimpleInput.ino
+++ b/examples/SimpleInput/SimpleInput.ino
@@ -17,6 +17,7 @@
 
 */
 
+#include <ItemInput.h>
 #include <LcdMenu.h>
 
 #define LCD_ROWS 2

--- a/examples/SubMenu/README.md
+++ b/examples/SubMenu/README.md
@@ -14,30 +14,26 @@ This example will show you how to get started with submenus
 ### 1 Create the main menu
 
 ```cpp
-// ../../examples/SubMenu/SubMenu.ino#L39-L46
-
 // Define the main menu
-MenuItem mainMenu[] = {ItemHeader(),
-                       MenuItem("Start service"),
-                       MenuItem("Connect to WiFi"),
-                       ItemSubMenu("Settings", settingsMenu),
-                       MenuItem("Blink SOS"),
-                       MenuItem("Blink random"),
-                       ItemFooter()};
+MAIN_MENU(
+    ITEM_BASIC("Start service"),
+    ITEM_BASIC("Connect to WiFi"),
+    ITEM_SUBMENU("Settings", settingsMenu),
+    ITEM_BASIC("Blink SOS"),
+    ITEM_BASIC("Blink random")
+);
 ```
 
 ### 2 Create the sub menu
 
 ```cpp
-// ../../examples/SubMenu/SubMenu.ino#L47-L53
-
 /**
  * Create submenu and precise its parent
  */
-MenuItem settingsMenu[] = {ItemHeader(mainMenu), MenuItem("Backlight"),
-                           MenuItem("Contrast"), ItemFooter()};
-
-LcdMenu menu(LCD_ROWS, LCD_COLS);
+SUB_MENU(settingsMenu, mainMenu,
+    ITEM_BASIC("Backlight"),
+    ITEM_BASIC("Contrast")
+);
 ```
 
 Go to [.../examples/SubMenu/SubMenu.ino](https://github.com/forntoh/LcdMenu/tree/master/examples/SubMenu/SubMenu.ino)

--- a/examples/SubMenu/SubMenu.ino
+++ b/examples/SubMenu/SubMenu.ino
@@ -32,23 +32,23 @@
 #define BACKSPACE 8  // BACKSPACE
 #define CLEAR 46     // NUMPAD .
 
-// Declare the main menu
-extern MenuItem mainMenu[];
-extern MenuItem settingsMenu[];
+extern MenuItem* settingsMenu[];
 
 // Define the main menu
-MenuItem mainMenu[] = {ItemHeader(),
-                       MenuItem("Start service"),
-                       MenuItem("Connect to WiFi"),
-                       ItemSubMenu("Settings", settingsMenu),
-                       MenuItem("Blink SOS"),
-                       MenuItem("Blink random"),
-                       ItemFooter()};
+MAIN_MENU(
+    ITEM_BASIC("Start service"),
+    ITEM_BASIC("Connect to WiFi"),
+    ITEM_SUBMENU("Settings", settingsMenu),
+    ITEM_BASIC("Blink SOS"),
+    ITEM_BASIC("Blink random")
+);
 /**
  * Create submenu and precise its parent
  */
-MenuItem settingsMenu[] = {ItemHeader(mainMenu), MenuItem("Backlight"),
-                           MenuItem("Contrast"), ItemFooter()};
+SUB_MENU(settingsMenu, mainMenu,
+    ITEM_BASIC("Backlight"),
+    ITEM_BASIC("Contrast")
+);
 
 LcdMenu menu(LCD_ROWS, LCD_COLS);
 

--- a/examples/SubMenu/SubMenu.ino
+++ b/examples/SubMenu/SubMenu.ino
@@ -16,7 +16,7 @@
  https://github.com/forntoh/LcdMenu/tree/master/examples/SubMenu/SubMenu.ino
 
 */
-
+#include <ItemSubMenu.h>
 #include <LcdMenu.h>
 
 #define LCD_ROWS 2
@@ -73,10 +73,4 @@ void loop() {
         menu.enter();
     else if (command == BACK)
         menu.back();
-    else if (command == CLEAR)
-        menu.clear();
-    else if (command == BACKSPACE)
-        menu.backspace();
-    else
-        menu.type(command);
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -6,29 +6,39 @@
 # Datatypes (KEYWORD1)
 #######################################
 
+ItemCommand	KEYWORD1
+ItemInput	KEYWORD1
+ItemList	KEYWORD1
+ItemSubMenu	KEYWORD1
+ItemToggle	KEYWORD1
 LcdMenu	KEYWORD1
 MenuItem	KEYWORD1
 ItemHeader	KEYWORD1
 ItemFooter	KEYWORD1
-ItemInput	KEYWORD1
-ItemSubMenu	KEYWORD1
-ItemToggle	KEYWORD1
-ItemCommand	KEYWORD1
-ItemList	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
+getCallback	KEYWORD2
+getValue	KEYWORD2
+setValue	KEYWORD2
+getCallbackStr	KEYWORD2
+getItemIndex	KEYWORD2
+getItems	KEYWORD2
+getCallbackInt	KEYWORD2
+isOn	KEYWORD2
+setIsOn	KEYWORD2
+getTextOn	KEYWORD2
+getTextOff	KEYWORD2
 drawCursor	KEYWORD2
 drawMenu	KEYWORD2
 isAtTheStart	KEYWORD2
 isAtTheEnd	KEYWORD2
-paint	KEYWORD2
 reset	KEYWORD2
 resetBlinker	KEYWORD2
 setupLcdWithMenu	KEYWORD2
-setSubMenu	KEYWORD2
+update	KEYWORD2
 up	KEYWORD2
 down	KEYWORD2
 enter	KEYWORD2
@@ -44,25 +54,24 @@ hide	KEYWORD2
 show	KEYWORD2
 isInEditMode	KEYWORD2
 getCursorPosition	KEYWORD2
+setCursorPosition	KEYWORD2
 displayNotification	KEYWORD2
 updateTimer	KEYWORD2
+isSubMenu	KEYWORD2
 getItemAt	KEYWORD2
 toggleBacklight	KEYWORD2
-getText	KEYWORD2
-getCallback	KEYWORD2
-getCallbackInt	KEYWORD2
-getCallbackStr	KEYWORD2
-getSubMenu	KEYWORD2
 getType	KEYWORD2
-getTextOn	KEYWORD2
-getTextOff	KEYWORD2
-getItems	KEYWORD2
-setText	KEYWORD2
-setCallBack	KEYWORD2
-setSubMenu	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
+ITEM_COMMAND	LITERAL1
+ITEM_INPUT	LITERAL1
+ITEM_STRING_LIST	LITERAL1
+ITEM_SUBMENU	LITERAL1
+ITEM_TOGGLE	LITERAL1
 USE_STANDARD_LCD	LITERAL1
+ITEM_BASIC	LITERAL1
+MAIN_MENU	LITERAL1
+SUB_MENU	LITERAL1

--- a/keywords.txt
+++ b/keywords.txt
@@ -39,6 +39,7 @@ reset	KEYWORD2
 resetBlinker	KEYWORD2
 setupLcdWithMenu	KEYWORD2
 update	KEYWORD2
+resetMenu	KEYWORD2
 up	KEYWORD2
 down	KEYWORD2
 enter	KEYWORD2

--- a/library.json
+++ b/library.json
@@ -1,8 +1,8 @@
 {
   "name": "LcdMenu",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "keywords": "menu, display, lcdmenu, navigation",
-  "description": "Display navigable menu items on your LCD display with Arduino. You can show items bound to actions, list of items (can select one), sub menus, step menu items e.t.c. Compatible with all Character LCD Display Module and VATN Alphanumeric LCD Display",
+  "description": "LcdMenu is an Arduino library that enables you to create interactive menus and navigation systems for LCD displays. With LcdMenu, you can easily add menus to your projects and navigate through them using buttons or any input device you want. The library supports a wide range of LCD display modules, including character and alphanumeric displays.",
   "repository": {
     "type": "git",
     "url": "https://github.com/forntoh/LcdMenu"

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=LcdMenu
-version=2.1.2
+version=3.0.0
 author=Forntoh Thomas <thomasforntoh@gmail.com>
 maintainer=Forntoh Thomas <thomasforntoh@gmail.com>
 sentence=Display navigable menu items on your LCD display with Arduino.
-paragraph=You can show items bound to actions, list of items (can select one), sub menus, step menu items e.t.c. Compatible with all Character LCD Display Module and VATN Alphanumeric LCD Display.
+paragraph=LcdMenu is an Arduino library that enables you to create interactive menus and navigation systems for LCD displays. With LcdMenu, you can easily add menus to your projects and navigate through them using buttons or any input device you want. The library supports a wide range of LCD display modules, including character and alphanumeric displays.
 category=Display
 url=https://forntoh.github.io/LcdMenu
 repository=https://github.com/forntoh/LcdMenu.git

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <Arduino.h>
+
+typedef void (*fptr)();
+typedef void (*fptrInt)(uint8_t);
+typedef void (*fptrStr)(String);
+//
+// menu item types
+//
+const byte MENU_ITEM_MAIN_MENU_HEADER = 1;
+const byte MENU_ITEM_SUB_MENU_HEADER = 2;
+const byte MENU_ITEM_SUB_MENU = 3;
+const byte MENU_ITEM_COMMAND = 4;
+const byte MENU_ITEM_INPUT = 5;
+const byte MENU_ITEM_NONE = 6;
+const byte MENU_ITEM_TOGGLE = 7;
+const byte MENU_ITEM_END_OF_MENU = 8;
+const byte MENU_ITEM_LIST = 9;

--- a/src/ItemCommand.h
+++ b/src/ItemCommand.h
@@ -49,4 +49,6 @@ class ItemCommand : public MenuItem {
     void setCallBack(fptr callback) override { this->callback = callback; };
 };
 
+#define ITEM_COMMAND(...) (new ItemCommand(__VA_ARGS__))
+
 #endif  // ITEM_COMMAND_H

--- a/src/ItemCommand.h
+++ b/src/ItemCommand.h
@@ -1,0 +1,32 @@
+/**
+ * ---
+ *
+ * # ItemCommand
+ *
+ * This item type indicates that the current item is a **command**.
+ * When `enter()` is invoked, the command *(callback)* bound to this item is
+ * invoked.
+ */
+
+#pragma once
+#define ItemCommand_H
+#include "MenuItem.h"
+
+class ItemCommand : public MenuItem {
+   private:
+    fptr callback;
+
+   public:
+    /**
+     * @param key key of the item
+     * @param callback reference to callback function
+     */
+    ItemCommand(const char* key, fptr callback)
+        : MenuItem(key, MENU_ITEM_COMMAND) {
+        this->callback = callback;
+    }
+
+    fptr getCallback() override { return callback; }
+
+    void setCallBack(fptr callback) override { this->callback = callback; };
+};

--- a/src/ItemCommand.h
+++ b/src/ItemCommand.h
@@ -8,25 +8,45 @@
  * invoked.
  */
 
-#pragma once
+#ifndef ItemCommand_H
 #define ItemCommand_H
+
+// Include the header file for the base class.
 #include "MenuItem.h"
 
+// Declare a class for menu items that represent commands.
 class ItemCommand : public MenuItem {
    private:
+    // Declare a function pointer for the command callback.
     fptr callback;
 
    public:
     /**
-     * @param key key of the item
-     * @param callback reference to callback function
+     * Construct a new ItemCommand object.
+     *
+     * @param key The key of the item.
+     * @param callback A reference to the callback function to be invoked when
+     * the item is entered.
      */
     ItemCommand(const char* key, fptr callback)
         : MenuItem(key, MENU_ITEM_COMMAND) {
         this->callback = callback;
     }
 
+    /**
+     * Get the callback function for this item.
+     *
+     * @return The function pointer to the callback function.
+     */
     fptr getCallback() override { return callback; }
 
+    /**
+     * Set the callback function for this item.
+     *
+     * @param callback A reference to the new callback function to be invoked
+     * when the item is entered.
+     */
     void setCallBack(fptr callback) override { this->callback = callback; };
 };
+
+#endif  // ITEM_COMMAND_H

--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -8,31 +8,63 @@
  * using `item->value`
  */
 
-#pragma once
+#ifndef ItemInput_H
 #define ItemInput_H
+
+// Include the header file for the base class.
 #include "MenuItem.h"
 
+// Declare a class for menu items that allow the user to input information.
 class ItemInput : public MenuItem {
    private:
+    // Declare a string to hold the input value.
     String value;
+
+    // Declare a function pointer for the input callback.
     fptrStr callback;
 
    public:
     /**
-     * @param text text to display for the item
-     * @param value the input value
-     * @param callback reference to callback function
+     * Construct a new ItemInput object with an initial value.
+     *
+     * @param text The text to display for the item.
+     * @param value The initial value for the input.
+     * @param callback A reference to the callback function to be invoked when
+     * the input is submitted.
      */
     ItemInput(const char* text, String value, fptrStr callback)
         : MenuItem(text, MENU_ITEM_INPUT), value(value), callback(callback) {}
+
     /**
+     * Construct a new ItemInput object with no initial value.
+     *
+     * @param text The text to display for the item.
+     * @param callback A reference to the callback function to be invoked when
+     * the input is submitted.
      */
     ItemInput(const char* text, fptrStr callback)
         : ItemInput(text, "", callback) {}
 
+    /**
+     * Get the current input value for this item.
+     *
+     * @return The current input value as a string.
+     */
     String getValue() override { return value; }
 
+    /**
+     * Set the input value for this item.
+     *
+     * @param value The new input value.
+     */
     void setValue(String value) override { this->value = value; }
 
+    /**
+     * Get the callback function for this item.
+     *
+     * @return The function pointer to the callback function.
+     */
     fptrStr getCallbackStr() override { return callback; }
 };
+
+#endif  // ITEM_INPUT_H

--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -67,4 +67,6 @@ class ItemInput : public MenuItem {
     fptrStr getCallbackStr() override { return callback; }
 };
 
+#define ITEM_INPUT(...) (new ItemInput(__VA_ARGS__))
+
 #endif  // ITEM_INPUT_H

--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -1,0 +1,38 @@
+/**
+ * ---
+ *
+ * # ItemInput
+ *
+ * This is an item type where a user can type in information,
+ * the information is persisted in the item and can be gotten later by
+ * using `item->value`
+ */
+
+#pragma once
+#define ItemInput_H
+#include "MenuItem.h"
+
+class ItemInput : public MenuItem {
+   private:
+    String value;
+    fptrStr callback;
+
+   public:
+    /**
+     * @param text text to display for the item
+     * @param value the input value
+     * @param callback reference to callback function
+     */
+    ItemInput(const char* text, String value, fptrStr callback)
+        : MenuItem(text, MENU_ITEM_INPUT), value(value), callback(callback) {}
+    /**
+     */
+    ItemInput(const char* text, fptrStr callback)
+        : ItemInput(text, "", callback) {}
+
+    String getValue() override { return value; }
+
+    void setValue(String value) override { this->value = value; }
+
+    fptrStr getCallbackStr() override { return callback; }
+};

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -19,6 +19,12 @@
 #include "MenuItem.h"
 
 class ItemList : public MenuItem {
+   private:
+    fptrInt callback = NULL;
+    String* items = NULL;
+    const uint8_t itemIndex = 0;
+    const uint8_t itemCount = 0;
+
    public:
     /**
      * @param key key of the items
@@ -28,5 +34,12 @@ class ItemList : public MenuItem {
      */
     ItemList(const char* key, String* items, uint8_t itemCount,
              fptrInt callback)
-        : MenuItem(key, items, itemCount, callback, MENU_ITEM_LIST) {}
+        : MenuItem(key, MENU_ITEM_LIST),
+          items(items),
+          itemCount(itemCount),
+          callback(callback) {}
+
+    uint8_t getItemIndex() override { return itemIndex; }
+    uint8_t getItemCount() override { return itemCount; };
+    String* getItems() override { return items; }
 };

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -4,33 +4,45 @@
  * # ItemList
  *
  * This item type indicates that the current item is a **list**.
- * - When `left()` is invoked the view cycles down the list
- * - When `right()` is invoked the view cycles up the list, you can use only
- *   `right()` if you have a single button, because once the menu reaches the
- *   end of the list, it automatically starts back from the begining.
- * - When `enter()` is invoked, the command *(callback)* bound to this item is
- *   invoked.
  *
- * > This can be used for other primitive data types, you just need to pass it
- * > as string then parse the result to the desired datatype
+ * ### Functionality
+ * - `left()`: cycles down the list
+ * - `right()`: cycles up the list. This function can be used alone with a
+ * single button. Once the menu reaches the end of the list, it automatically
+ * starts back from the beginning.
+ * - `enter()`: invokes the command *(callback)* bound to this item.
+ *
+ * ### Usage
+ * This item can be used for other primitive data types; you just need to pass
+ * it as a string, then parse the result to the desired datatype.
+ *
+ * ### Parameters
+ * @param key: key of the items
+ * @param items: array of items to display
+ * @param itemCount: number of items in `items`
+ * @param callback: reference to a callback function that will be invoked
+ * when the user selects an item from the list.
  */
-#pragma once
+#ifndef ItemList_H
 #define ItemList_H
 #include "MenuItem.h"
 
 class ItemList : public MenuItem {
    private:
-    fptrInt callback = NULL;
-    String* items = NULL;
-    const uint8_t itemIndex = 0;
-    const uint8_t itemCount = 0;
+    fptrInt callback = NULL;      ///< Pointer to a callback function
+    String* items = NULL;         ///< Pointer to an array of items
+    const uint8_t itemIndex = 0;  ///< The current selected item index
+    const uint8_t itemCount = 0;  ///< The total number of items in the list
 
    public:
     /**
-     * @param key key of the items
-     * @param items items to display
-     * @param itemCount number of items in `items`
-     * @param callback reference to callback function
+     * @brief Constructs a new ItemList object.
+     *
+     * @param key The key of the menu item.
+     * @param items The array of items to display.
+     * @param itemCount The number of items in the array.
+     * @param callback A pointer to the callback function to execute when
+     * this menu item is selected.
      */
     ItemList(const char* key, String* items, uint8_t itemCount,
              fptrInt callback)
@@ -39,7 +51,26 @@ class ItemList : public MenuItem {
           itemCount(itemCount),
           callback(callback) {}
 
+    /**
+     * @brief Returns the index of the currently selected item.
+     *
+     * @return The index of the currently selected item.
+     */
     uint8_t getItemIndex() override { return itemIndex; }
+
+    /**
+     * @brief Returns the total number of items in the list.
+     *
+     * @return The total number of items in the list.
+     */
     uint8_t getItemCount() override { return itemCount; };
+
+    /**
+     * @brief Returns a pointer to the array of items.
+     *
+     * @return A pointer to the array of items.
+     */
     String* getItems() override { return items; }
 };
+
+#endif

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -32,7 +32,7 @@ class ItemList : public MenuItem {
     fptrInt callback = NULL;  ///< Pointer to a callback function
     String* items = NULL;     ///< Pointer to an array of items
     const uint8_t itemCount;  ///< The total number of items in the list
-    uint8_t itemIndex;        ///< The current selected item index
+    uint8_t itemIndex = 0;    ///< The current selected item index
 
    public:
     /**
@@ -49,7 +49,6 @@ class ItemList : public MenuItem {
         : MenuItem(key, MENU_ITEM_LIST),
           items(items),
           itemCount(itemCount),
-          itemIndex(0),
           callback(callback) {}
 
     /**

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -1,0 +1,32 @@
+/**
+ * ---
+ *
+ * # ItemList
+ *
+ * This item type indicates that the current item is a **list**.
+ * - When `left()` is invoked the view cycles down the list
+ * - When `right()` is invoked the view cycles up the list, you can use only
+ *   `right()` if you have a single button, because once the menu reaches the
+ *   end of the list, it automatically starts back from the begining.
+ * - When `enter()` is invoked, the command *(callback)* bound to this item is
+ *   invoked.
+ *
+ * > This can be used for other primitive data types, you just need to pass it
+ * > as string then parse the result to the desired datatype
+ */
+#pragma once
+#define ItemList_H
+#include "MenuItem.h"
+
+class ItemList : public MenuItem {
+   public:
+    /**
+     * @param key key of the items
+     * @param items items to display
+     * @param itemCount number of items in `items`
+     * @param callback reference to callback function
+     */
+    ItemList(const char* key, String* items, uint8_t itemCount,
+             fptrInt callback)
+        : MenuItem(key, items, itemCount, callback, MENU_ITEM_LIST) {}
+};

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -29,9 +29,9 @@
 
 class ItemList : public MenuItem {
    private:
+    const uint8_t itemCount;  ///< The total number of items in the list
     fptrInt callback = NULL;  ///< Pointer to a callback function
     String* items = NULL;     ///< Pointer to an array of items
-    const uint8_t itemCount;  ///< The total number of items in the list
     uint8_t itemIndex = 0;    ///< The current selected item index
 
    public:
@@ -47,8 +47,8 @@ class ItemList : public MenuItem {
     ItemList(const char* key, String* items, const uint8_t itemCount,
              fptrInt callback)
         : MenuItem(key, MENU_ITEM_LIST),
-          items(items),
           itemCount(itemCount),
+          items(items),
           callback(callback) {}
 
     /**
@@ -72,5 +72,7 @@ class ItemList : public MenuItem {
      */
     String* getItems() override { return items; }
 };
+
+#define ITEM_STRING_LIST(...) (new ItemList(__VA_ARGS__))
 
 #endif

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -29,10 +29,10 @@
 
 class ItemList : public MenuItem {
    private:
-    fptrInt callback = NULL;      ///< Pointer to a callback function
-    String* items = NULL;         ///< Pointer to an array of items
-    const uint8_t itemIndex = 0;  ///< The current selected item index
-    const uint8_t itemCount = 0;  ///< The total number of items in the list
+    fptrInt callback = NULL;  ///< Pointer to a callback function
+    String* items = NULL;     ///< Pointer to an array of items
+    const uint8_t itemCount;  ///< The total number of items in the list
+    uint8_t itemIndex;        ///< The current selected item index
 
    public:
     /**
@@ -44,11 +44,12 @@ class ItemList : public MenuItem {
      * @param callback A pointer to the callback function to execute when
      * this menu item is selected.
      */
-    ItemList(const char* key, String* items, uint8_t itemCount,
+    ItemList(const char* key, String* items, const uint8_t itemCount,
              fptrInt callback)
         : MenuItem(key, MENU_ITEM_LIST),
           items(items),
           itemCount(itemCount),
+          itemIndex(0),
           callback(callback) {}
 
     /**

--- a/src/ItemSubMenu.h
+++ b/src/ItemSubMenu.h
@@ -1,0 +1,22 @@
+/**
+ * ---
+ *
+ * # ItemSubMenu
+ *
+ * This item type indicates that the current item contains a sub menu.
+ * The sub menu is opened when `enter()` is invoked.
+ */
+
+#pragma once
+#define ItemSubMenu_H
+#include "MenuItem.h"
+
+class ItemSubMenu : public MenuItem {
+   public:
+    /**
+     * @param text text to display for the item
+     * @param parent the parent of the sub menu item
+     */
+    ItemSubMenu(const char* text, MenuItem* parent)
+        : MenuItem(text, parent, MENU_ITEM_SUB_MENU) {}
+};

--- a/src/ItemSubMenu.h
+++ b/src/ItemSubMenu.h
@@ -7,7 +7,7 @@
  * The sub menu is opened when `enter()` is invoked.
  */
 
-#pragma once
+#ifndef ItemSubMenu_H
 #define ItemSubMenu_H
 #include "MenuItem.h"
 
@@ -20,3 +20,4 @@ class ItemSubMenu : public ItemHeader {
     ItemSubMenu(const char* text, MenuItem* parent)
         : ItemHeader(text, parent, MENU_ITEM_SUB_MENU) {}
 };
+#endif

--- a/src/ItemSubMenu.h
+++ b/src/ItemSubMenu.h
@@ -17,7 +17,7 @@ class ItemSubMenu : public ItemHeader {
      * @param text text to display for the item
      * @param parent the parent of the sub menu item
      */
-    ItemSubMenu(const char* text, MenuItem* parent)
+    ItemSubMenu(const char* text, MenuItem** parent)
         : ItemHeader(text, parent, MENU_ITEM_SUB_MENU) {}
 };
 #endif

--- a/src/ItemSubMenu.h
+++ b/src/ItemSubMenu.h
@@ -11,12 +11,12 @@
 #define ItemSubMenu_H
 #include "MenuItem.h"
 
-class ItemSubMenu : public MenuItem {
+class ItemSubMenu : public ItemHeader {
    public:
     /**
      * @param text text to display for the item
      * @param parent the parent of the sub menu item
      */
     ItemSubMenu(const char* text, MenuItem* parent)
-        : MenuItem(text, parent, MENU_ITEM_SUB_MENU) {}
+        : ItemHeader(text, parent, MENU_ITEM_SUB_MENU) {}
 };

--- a/src/ItemSubMenu.h
+++ b/src/ItemSubMenu.h
@@ -20,4 +20,7 @@ class ItemSubMenu : public ItemHeader {
     ItemSubMenu(const char* text, MenuItem** parent)
         : ItemHeader(text, parent, MENU_ITEM_SUB_MENU) {}
 };
+
+#define ITEM_SUBMENU(...) (new ItemSubMenu(__VA_ARGS__))
+
 #endif

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -33,8 +33,7 @@ class ItemToggle : public MenuItem {
      * @param textOff display text when OFF
      * @param callback reference to callback function
      */
-    ItemToggle(const char* key, const char* textOn, const char* textOff,
-               fptrInt callback)
+    ItemToggle(const char* key, char* textOn, char* textOff, fptrInt callback)
         : MenuItem(key, MENU_ITEM_TOGGLE),
           textOn(textOn),
           textOff(textOff),

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -7,7 +7,7 @@
  * When `enter()` is invoked, the state of `isOn` is toggled.
  */
 
-#pragma once
+#ifndef ItemToggle_H
 #define ItemToggle_H
 #include "MenuItem.h"
 
@@ -25,7 +25,9 @@ class ItemToggle : public MenuItem {
      */
     ItemToggle(const char* key, fptrInt callback)
         : ItemToggle(key, "ON", "OFF", callback) {}
+
     /**
+     * @brief Create an ItemToggle object.
      * @param key key of the item
      * @param textOn display text when ON
      * @param textOff display text when OFF
@@ -38,9 +40,22 @@ class ItemToggle : public MenuItem {
           textOff(textOff),
           callback(callback) {}
 
+    /**
+     * @brief Get the integer callback function of this item.
+     * @return the integer callback function
+     */
     fptrInt getCallbackInt() override { return callback; }
 
+    /**
+     * @brief Get the current state of this toggle item.
+     * @return the current state
+     */
     boolean isOn() override { return enabled; }
 
+    /**
+     * @brief Set the current state of this toggle item.
+     * @param isOn the new state
+     */
     void setIsOn(boolean isOn) override { this->enabled = isOn; }
 };
+#endif

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -33,7 +33,8 @@ class ItemToggle : public MenuItem {
      * @param textOff display text when OFF
      * @param callback reference to callback function
      */
-    ItemToggle(const char* key, char* textOn, char* textOff, fptrInt callback)
+    ItemToggle(const char* key, const char* textOn, const char* textOff,
+               fptrInt callback)
         : MenuItem(key, MENU_ITEM_TOGGLE),
           textOn(textOn),
           textOff(textOff),
@@ -56,5 +57,12 @@ class ItemToggle : public MenuItem {
      * @param isOn the new state
      */
     void setIsOn(boolean isOn) override { this->enabled = isOn; }
+
+    const char* getTextOn() override { return this->textOn; }
+
+    const char* getTextOff() override { return this->textOff; }
 };
+
+#define ITEM_TOGGLE(...) (new ItemToggle(__VA_ARGS__))
+
 #endif

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -1,0 +1,46 @@
+/**
+ * ---
+ *
+ * # ItemToggle
+ *
+ * This item type indicates that the current item is **toggleable**.
+ * When `enter()` is invoked, the state of `isOn` is toggled.
+ */
+
+#pragma once
+#define ItemToggle_H
+#include "MenuItem.h"
+
+class ItemToggle : public MenuItem {
+   private:
+    bool enabled = false;
+    const char* textOn = NULL;
+    const char* textOff = NULL;
+    fptrInt callback = NULL;
+
+   public:
+    /**
+     * @param key key of the item
+     * @param callback reference to callback function
+     */
+    ItemToggle(const char* key, fptrInt callback)
+        : ItemToggle(key, "ON", "OFF", callback) {}
+    /**
+     * @param key key of the item
+     * @param textOn display text when ON
+     * @param textOff display text when OFF
+     * @param callback reference to callback function
+     */
+    ItemToggle(const char* key, const char* textOn, const char* textOff,
+               fptrInt callback)
+        : MenuItem(key, MENU_ITEM_TOGGLE),
+          textOn(textOn),
+          textOff(textOff),
+          callback(callback) {}
+
+    fptrInt getCallbackInt() override { return callback; }
+
+    boolean isOn() override { return enabled; }
+
+    void setIsOn(boolean isOn) override { this->enabled = isOn; }
+};

--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -182,8 +182,8 @@ class LcdMenu {
                     // append textOn or textOff depending on the state
                     //
                     lcd->print(":");
-                    lcd->print(item->isOn ? item->getTextOn()
-                                          : item->getTextOff());
+                    lcd->print(item->isOn() ? item->getTextOn()
+                                            : item->getTextOff());
                     break;
 #endif
 #ifdef ItemInput_H
@@ -192,7 +192,7 @@ class LcdMenu {
                     // append the value of the input
                     //
                     lcd->print(":");
-                    lcd->print(item->value.substring(
+                    lcd->print(item->getValue().substring(
                         0, maxCols - strlen(item->getText()) - 2));
                     break;
 #endif
@@ -286,7 +286,7 @@ class LcdMenu {
         // calculate lower and upper bound
         //
         uint8_t lb = strlen(currentMenuTable[cursorPosition].getText()) + 2;
-        uint8_t ub = lb + currentMenuTable[cursorPosition].value.length();
+        uint8_t ub = lb + currentMenuTable[cursorPosition].getValue().length();
         ub = constrain(ub, lb, maxCols - 2);
         //
         // set cursor position
@@ -471,12 +471,12 @@ class LcdMenu {
                 //
                 // toggle the value of isOn
                 //
-                item->isOn = !item->isOn;
+                item->setIsOn(!item->isOn());
                 //
                 // execute the menu item's function
                 //
                 if (item->getCallbackInt() != NULL)
-                    (item->getCallbackInt())(item->isOn);
+                    (item->getCallbackInt())(item->isOn());
                 //
                 // display the menu again
                 //
@@ -527,7 +527,7 @@ class LcdMenu {
             update();
             // Execute callback function
             if (item->getCallbackStr() != NULL)
-                (item->getCallbackStr())(item->value);
+                (item->getCallbackStr())(item->getValue());
             // Interrupt going back to parent menu
             return;
         }
@@ -625,7 +625,7 @@ class LcdMenu {
         if (item->getType() != MENU_ITEM_INPUT) return;
         //
         uint8_t p = blinkerPosition - (strlen(item->getText()) + 2) - 1;
-        item->value.remove(p, 1);
+        item->getValue().remove(p, 1);
         blinkerPosition--;
         update();
     }
@@ -642,18 +642,18 @@ class LcdMenu {
         // calculate lower and upper bound
         //
         uint8_t lb = strlen(item->getText()) + 2;
-        uint8_t ub = lb + item->value.length();
+        uint8_t ub = lb + item->getValue().length();
         ub = constrain(ub, lb, maxCols - 2);
         //
         // update text
         //
         if (blinkerPosition < ub) {
-            String start = item->value.substring(0, blinkerPosition - lb);
-            String end = item->value.substring(blinkerPosition + 1 - lb,
-                                               item->value.length());
-            item->value = start + character + end;
+            String start = item->getValue().substring(0, blinkerPosition - lb);
+            String end = item->getValue().substring(blinkerPosition + 1 - lb,
+                                                    item->getValue().length());
+            item->setValue(start + character + end);
         } else
-            item->value.concat(character);
+            item->getValue().concat(character);
         //
         isCharPickerActive = false;
         //
@@ -694,7 +694,7 @@ class LcdMenu {
         //
         // set the value
         //
-        item->value = "";
+        item->setValue("");
         //
         // update blinker position
         //
@@ -816,7 +816,7 @@ class LcdMenu {
     void toggleBacklight() {
         MenuItem* item = &currentMenuTable[cursorPosition];
         if (item->getType() == MENU_ITEM_TOGGLE) {
-            lcd->setBacklight(item->isOn);
+            lcd->setBacklight(item->isOn());
         }
     }
 #endif

--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -23,9 +23,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 */
-
-#ifndef LcdMenu_H
-#define LcdMenu_H
+#pragma once
 
 #ifndef USE_STANDARD_LCD
 #include <LiquidCrystal_I2C.h>
@@ -145,6 +143,7 @@ class LcdMenu {
         uint8_t line = constrain(cursorPosition - top, 0, maxRows - 1);
         lcd->setCursor(0, line);
         lcd->write(cursorIcon);
+#ifdef ItemInput_H
         //
         // If cursor is at MENU_ITEM_INPUT enable blinking
         //
@@ -156,6 +155,7 @@ class LcdMenu {
                 return;
             }
         }
+#endif
         lcd->noBlink();
     }
     /**
@@ -176,6 +176,7 @@ class LcdMenu {
             // determine the type of item
             //
             switch (item->getType()) {
+#ifdef ItemToggle_H
                 case MENU_ITEM_TOGGLE:
                     //
                     // append textOn or textOff depending on the state
@@ -184,6 +185,8 @@ class LcdMenu {
                     lcd->print(item->isOn ? item->getTextOn()
                                           : item->getTextOff());
                     break;
+#endif
+#ifdef ItemInput_H
                 case MENU_ITEM_INPUT:
                     //
                     // append the value of the input
@@ -192,6 +195,8 @@ class LcdMenu {
                     lcd->print(item->value.substring(
                         0, maxCols - strlen(item->getText()) - 2));
                     break;
+#endif
+#ifdef ItemList_H
                 case MENU_ITEM_LIST:
                     //
                     // append the value of the item at current list position
@@ -200,6 +205,7 @@ class LcdMenu {
                     lcd->print(item->getItems()[item->itemIndex].substring(
                         0, maxCols - strlen(item->getText()) - 2));
                     break;
+#endif
                 default:
                     break;
             }
@@ -271,6 +277,7 @@ class LcdMenu {
         }
         update();
     }
+#ifdef ItemInput_H
     /**
      * Calculate and set the new blinker position
      */
@@ -287,6 +294,7 @@ class LcdMenu {
         blinkerPosition = constrain(blinkerPosition, lb, ub);
         lcd->setCursor(blinkerPosition, cursorPosition - top);
     }
+#endif
 
    public:
     /**
@@ -442,6 +450,7 @@ class LcdMenu {
                 reset(false);
                 break;
             }
+#ifdef ItemCommand_H
             //
             // execute the menu item's function
             //
@@ -456,6 +465,8 @@ class LcdMenu {
                 update();
                 break;
             }
+#endif
+#ifdef ItemToggle_H
             case MENU_ITEM_TOGGLE: {
                 //
                 // toggle the value of isOn
@@ -472,6 +483,8 @@ class LcdMenu {
                 update();
                 break;
             }
+#endif
+#ifdef ItemInput_H
             case MENU_ITEM_INPUT: {
                 //
                 // enter editmode
@@ -484,6 +497,8 @@ class LcdMenu {
 
                 break;
             }
+#endif
+#ifdef ItemList_H
             case MENU_ITEM_LIST: {
                 //
                 // execute the menu item's function
@@ -492,6 +507,7 @@ class LcdMenu {
                     (item->getCallbackInt())(item->itemIndex);
                 break;
             }
+#endif
         }
     }
     /**
@@ -500,6 +516,7 @@ class LcdMenu {
      * Navigates up once.
      */
     void back() {
+#ifdef ItemInput_H
         MenuItem* item = &currentMenuTable[cursorPosition];
         //
         // Back action different when on ItemInput
@@ -514,6 +531,7 @@ class LcdMenu {
             // Interrupt going back to parent menu
             return;
         }
+#endif
         //
         // check if this is a sub menu, if so go back to its parent
         //
@@ -537,18 +555,25 @@ class LcdMenu {
         //
         // get the type of the currently displayed menu
         //
+#ifdef ItemList_H
         uint8_t previousIndex = item->itemIndex;
+#endif
         switch (item->getType()) {
+#ifdef ItemList_H
             case MENU_ITEM_LIST: {
                 item->itemIndex =
                     constrain(item->itemIndex - 1, 0, item->itemCount - 1);
                 if (previousIndex != item->itemIndex) update();
                 break;
             }
-            default:
+#endif
+#ifdef ItemInput_H
+            case MENU_ITEM_INPUT: {
                 blinkerPosition--;
                 resetBlinker();
                 break;
+            }
+#endif
         }
     }
     /**
@@ -569,18 +594,24 @@ class LcdMenu {
         // get the type of the currently displayed menu
         //
         switch (item->getType()) {
+#ifdef ItemList_H
             case MENU_ITEM_LIST: {
                 item->itemIndex = (item->itemIndex + 1) % item->itemCount;
                 // constrain(item->itemIndex + 1, 0, item->itemCount - 1);
                 update();
                 break;
             }
-            default:
+#endif
+#ifdef ItemInput_H
+            case MENU_ITEM_INPUT: {
                 blinkerPosition++;
                 resetBlinker();
                 break;
+            }
+#endif
         }
     }
+#ifdef ItemInput_H
     /**
      * Execute a "backspace cmd" on menu
      *
@@ -673,6 +704,7 @@ class LcdMenu {
         //
         update();
     }
+#endif
     /**
      * Set the character used to visualize the cursor.
      * @param newIcon character to display
@@ -711,17 +743,8 @@ class LcdMenu {
      * Set the current cursor position
      * @param position
      */
-    void setCursorPosition(uint8_t position) { this->cursorPosition = position; }
-    /**
-     * @brief Execute a callback after [delay] milliseconds
-     *
-     * @param callback The callback to be executed
-     * @param delay Delay time in milliseconds
-     */
-    void run(fptr callback, uint8_t delay) {
-        this->delay = delay;
-        this->startTime = millis();
-        if (millis() == startTime + delay) fptr();
+    void setCursorPosition(uint8_t position) {
+        this->cursorPosition = position;
     }
     /**
      * Show a message at the bottom of the screen
@@ -786,6 +809,7 @@ class LcdMenu {
     MenuItem* operator[](const uint8_t position) {
         return &currentMenuTable[position];
     }
+#ifdef ItemToggle_H
     /**
      * Toggle backlight
      */
@@ -795,5 +819,5 @@ class LcdMenu {
             lcd->setBacklight(item->isOn);
         }
     }
-};
 #endif
+};

--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -202,7 +202,7 @@ class LcdMenu {
                     // append the value of the item at current list position
                     //
                     lcd->print(":");
-                    lcd->print(item->getItems()[item->itemIndex].substring(
+                    lcd->print(item->getItems()[item->getItemIndex()].substring(
                         0, maxCols - strlen(item->getText()) - 2));
                     break;
 #endif
@@ -359,15 +359,6 @@ class LcdMenu {
         this->currentMenuTable = menu;
         update();
     }
-    /**
-     * Call this function to set sub menu items for any main menu item
-     * @param position main menu item/where to place the sub menu
-     * @param items    sub menu items
-     */
-    void setSubMenu(uint8_t position, MenuItem* items) {
-        currentMenuTable[position + 1].setSubMenu(items);
-        update();
-    }
     /*
      * Draw the menu items and cursor
      */
@@ -504,7 +495,7 @@ class LcdMenu {
                 // execute the menu item's function
                 //
                 if (item->getCallbackInt() != NULL)
-                    (item->getCallbackInt())(item->itemIndex);
+                    (item->getCallbackInt())(item->getItemIndex());
                 break;
             }
 #endif
@@ -556,14 +547,14 @@ class LcdMenu {
         // get the type of the currently displayed menu
         //
 #ifdef ItemList_H
-        uint8_t previousIndex = item->itemIndex;
+        uint8_t previousIndex = item->getItemIndex();
 #endif
         switch (item->getType()) {
 #ifdef ItemList_H
             case MENU_ITEM_LIST: {
-                item->itemIndex =
-                    constrain(item->itemIndex - 1, 0, item->itemCount - 1);
-                if (previousIndex != item->itemIndex) update();
+                item->setItemIndex(constrain(item->getItemIndex() - 1, 0,
+                                             item->getItemCount() - 1));
+                if (previousIndex != item->getItemIndex()) update();
                 break;
             }
 #endif
@@ -596,7 +587,8 @@ class LcdMenu {
         switch (item->getType()) {
 #ifdef ItemList_H
             case MENU_ITEM_LIST: {
-                item->itemIndex = (item->itemIndex + 1) % item->itemCount;
+                item->setItemIndex((item->getItemIndex() + 1) %
+                                   item->getItemCount());
                 // constrain(item->itemIndex + 1, 0, item->itemCount - 1);
                 update();
                 break;

--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -368,6 +368,10 @@ class LcdMenu {
         drawCursor();
     }
     /**
+     * Reset the display
+     */
+    void resetMenu() { this->reset(false); }
+    /**
      * Execute an "up press" on menu
      * When edit mode is enabled, this action is skipped
      */

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -38,10 +38,6 @@ class MenuItem {
     byte type = MENU_ITEM_NONE;
 
    public:
-    /**
-     * ## Public Fields
-     */
-
     MenuItem() = default;
     MenuItem(const char* text) : text(text) {}
     MenuItem(const char* text, byte type) : text(text), type(type) {}

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -163,22 +163,22 @@ class MenuItem {
 
 class ItemHeader : public MenuItem {
    protected:
-    MenuItem* parent = NULL;
+    MenuItem** parent = NULL;
 
-    ItemHeader(const char* text, MenuItem* parent, byte type)
+    ItemHeader(const char* text, MenuItem** parent, byte type)
         : MenuItem(NULL, type), parent(parent) {}
 
    public:
     /**
      */
-    ItemHeader() : ItemHeader(this) {}
+    ItemHeader() : ItemHeader(NULL) {}
     /**
      * @param parent the parent menu item
      */
-    ItemHeader(MenuItem* parent)
+    ItemHeader(MenuItem** parent)
         : ItemHeader("", parent, MENU_ITEM_SUB_MENU_HEADER) {}
 
-    MenuItem* getSubMenu() override { return this->parent; };
+    MenuItem** getSubMenu() override { return this->parent; };
 };
 
 /**

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -76,7 +76,7 @@ class MenuItem {
      * Get the sub menu at item
      * @return `MenuItem*` - Submenu at item
      */
-    virtual MenuItem* getSubMenu() { return NULL; }
+    virtual MenuItem** getSubMenu() { return NULL; }
     /**
      * Get the type of the item
      * @return `byte` - type of menu item
@@ -143,6 +143,7 @@ class MenuItem {
      */
     MenuItem& operator[](const uint8_t index);
 };
+#define ITEM_BASIC(...) (new MenuItem(__VA_ARGS__))
 
 /**
  *
@@ -205,5 +206,9 @@ class ItemFooter : public MenuItem {
      */
     ItemFooter() : MenuItem(NULL, MENU_ITEM_END_OF_MENU) {}
 };
+
+#define MAIN_MENU(...)           \
+    extern MenuItem* mainMenu[]; \
+    MenuItem* mainMenu[] = {new ItemHeader(), __VA_ARGS__, new ItemFooter()}
 
 #endif

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -36,21 +36,11 @@ class MenuItem {
    protected:
     const char* text = NULL;
     byte type = MENU_ITEM_NONE;
-    String* items = NULL;
 
    public:
     /**
      * ## Public Fields
      */
-
-    /**
-     * Current index of list for `ItemList`
-     */
-    uint8_t itemIndex = 0;
-    /**
-     * Number of items in the list for `ItemList`
-     */
-    uint8_t itemCount = 0;
 
     MenuItem() = default;
     MenuItem(const char* text) : text(text) {}
@@ -108,10 +98,18 @@ class MenuItem {
      */
     virtual const char* getTextOff() { return ""; }
     /**
+     * Current index of list for `ItemList`
+     */
+    virtual uint8_t getItemIndex() { return 0; }
+    /**
+     * Number of items in the list for `ItemList`
+     */
+    virtual uint8_t getItemCount() { return 0; };
+    /**
      * Get the list of items
      * @return `String*` - List of items
      */
-    virtual String* getItems() { return items; }
+    virtual String* getItems() { return NULL; }
 
     /**
      * ## Setters
@@ -136,10 +134,9 @@ class MenuItem {
      */
     virtual void setCallBack(fptr callback){};
     /**
-     * Set the sub menu on the item
-     * @param subMenu for the item
+     * Current index of list for `ItemList`
      */
-    void setSubMenu(MenuItem* subMenu){};
+    virtual void setItemIndex(uint8_t itemIndex){};
 
     /**
      * Operators
@@ -170,8 +167,11 @@ class MenuItem {
  */
 
 class ItemHeader : public MenuItem {
-   private:
+   protected:
     MenuItem* parent = NULL;
+
+    ItemHeader(const char* text, MenuItem* parent, byte type)
+        : MenuItem(NULL, type), parent(parent) {}
 
    public:
     /**
@@ -181,7 +181,7 @@ class ItemHeader : public MenuItem {
      * @param parent the parent menu item
      */
     ItemHeader(MenuItem* parent)
-        : MenuItem(NULL, MENU_ITEM_SUB_MENU_HEADER), parent(parent) {}
+        : ItemHeader("", parent, MENU_ITEM_SUB_MENU_HEADER) {}
 
     MenuItem* getSubMenu() override { return this->parent; };
 };

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -211,4 +211,8 @@ class ItemFooter : public MenuItem {
     extern MenuItem* mainMenu[]; \
     MenuItem* mainMenu[] = {new ItemHeader(), __VA_ARGS__, new ItemFooter()}
 
+#define SUB_MENU(subMenu, parent, ...)                          \
+    MenuItem* subMenu[] = {new ItemHeader(parent), __VA_ARGS__, \
+                           new ItemFooter()}
+
 #endif

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -3,7 +3,7 @@
 
   MIT License
 
-  Copyright (c) 2020-2021 Forntoh Thomas
+  Copyright (c) 2020-2023 Forntoh Thomas
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,6 @@ class MenuItem {
     byte type = MENU_ITEM_NONE;
 
    public:
-    MenuItem() = default;
     MenuItem(const char* text) : text(text) {}
     MenuItem(const char* text, byte type) : text(text), type(type) {}
     /**
@@ -87,12 +86,12 @@ class MenuItem {
      * Get the text when toggle is ON
      * @return `String` - ON text
      */
-    virtual const char* getTextOn() { return ""; }
+    virtual const char* getTextOn() { return NULL; }
     /**
      * Get the text when toggle is OFF
      * @return `String` - OFF text
      */
-    virtual const char* getTextOff() { return ""; }
+    virtual const char* getTextOff() { return NULL; }
     /**
      * Current index of list for `ItemList`
      */

--- a/wokwi.toml
+++ b/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version=1
+firmware='.pio/build/uno/firmware.hex'
+elf='.pio/build/uno/firmware.elf'


### PR DESCRIPTION
The current implementation of the menu uses a lot of memory since space has to be reserved for every field on the menu even if it is not used, this PR will fix that by allowing the user to import only MenuItems which is needed by the user. #62 
 - Fields have been moded from MenuItem to each implementation, saving memory if a field is not needed

With this PR you can expect to save up to 10% on memory usage (or even more), depending on which menu item types you use.

I used this as an opportunity to revamp the library, how menus are created has been changed, please check the readme