### PR TITLE
Update callback function parameter types to use `uint16_t` instead of `uint8_t`.

### DIFF
--- a/examples/Callbacks/Callbacks.ino
+++ b/examples/Callbacks/Callbacks.ino
@@ -23,7 +23,7 @@
 #define CLEAR 46     // NUMPAD .
 
 // Declare the call back function
-void toggleBacklight(uint8_t isOn);
+void toggleBacklight(uint16_t isOn);
 
 // prettier-ignore
 MAIN_MENU(
@@ -61,4 +61,4 @@ void loop() {
 /**
  * Define callback
  */
-void toggleBacklight(uint8_t isOn) { menu.setBacklight(isOn); }
+void toggleBacklight(uint16_t isOn) { menu.setBacklight(isOn); }

--- a/examples/IntFloatValues/IntFloatValues.ino
+++ b/examples/IntFloatValues/IntFloatValues.ino
@@ -22,7 +22,7 @@
 #define CLEAR 46     // NUMPAD .
 
 // Declare the calbacks
-void callback(uint8_t pos);
+void callback(uint16_t pos);
 
 char* intMapping(uint16_t progress) {
     // Map the progress value to a new range (100 to 200)
@@ -53,7 +53,7 @@ char* floatMapping(uint16_t progress) {
     // decimal point) and 2 decimal places
     dtostrf(floatValue, 4, 2, buffer);
 
-    // Concatenate the string with the character 'c'
+    // Concatenate the string with the character 'A'
     concat(buffer, 'A', buffer);
 
     // Return the resulting string
@@ -96,7 +96,7 @@ void loop() {
         menu.back();
 }
 
-void callback(uint8_t pos) {
+void callback(uint16_t pos) {
     // do something with the progress
     Serial.println(pos);
 }

--- a/examples/List/List.ino
+++ b/examples/List/List.ino
@@ -22,8 +22,8 @@
 #define CLEAR 46     // NUMPAD .
 
 // Declare the calbacks
-void colorsCallback(uint8_t pos);
-void numsCallback(uint8_t pos);
+void colorsCallback(uint16_t pos);
+void numsCallback(uint16_t pos);
 
 // Declare the array
 extern String colors[];
@@ -74,12 +74,12 @@ void loop() {
 }
 
 // Define the calbacks
-void colorsCallback(uint8_t pos) {
+void colorsCallback(uint16_t pos) {
     // do something with the index
     Serial.println(colors[pos]);
 }
 
-void numsCallback(uint8_t pos) {
+void numsCallback(uint16_t pos) {
     // do something with the index
     Serial.println(nums[pos]);
 }

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -2,7 +2,7 @@
 #include <Arduino.h>
 
 typedef void (*fptr)();
-typedef void (*fptrInt)(uint8_t);
+typedef void (*fptrInt)(uint16_t);
 typedef void (*fptrStr)(char*);
 typedef char* (*fptrMapping)(uint16_t);
 //

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -56,7 +56,7 @@ class ItemList : public MenuItem {
      *
      * @return The index of the currently selected item.
      */
-    uint8_t getItemIndex() override { return itemIndex; }
+    uint16_t getItemIndex() override { return itemIndex; }
 
     /**
      * @brief Changes the index of the current item.

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -32,7 +32,7 @@ class ItemList : public MenuItem {
     fptrInt callback = NULL;  ///< Pointer to a callback function
     String* items = NULL;     ///< Pointer to an array of items
     const uint8_t itemCount;  ///< The total number of items in the list
-    uint8_t itemIndex = 0;    ///< The current selected item index
+    uint16_t itemIndex = 0;   ///< The current selected item index
 
    public:
     /**
@@ -63,7 +63,7 @@ class ItemList : public MenuItem {
      *
      * @return The index of the item to be selected.
      */
-    void setItemIndex(uint8_t itemIndex) override {
+    void setItemIndex(uint16_t itemIndex) override {
         this->itemIndex = constrain(itemIndex, 0, itemCount - 1);
     }
 

--- a/src/ItemProgress.h
+++ b/src/ItemProgress.h
@@ -66,7 +66,7 @@ class ItemProgress : public MenuItem {
     /**
      * Return the progress
      */
-    uint8_t getItemIndex() override { return progress; }
+    uint16_t getItemIndex() override { return progress; }
 
     /**
      * Return the callback

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -95,7 +95,7 @@ class MenuItem {
     /**
      * Current index of list for `ItemList`
      */
-    virtual uint8_t getItemIndex() { return 0; }
+    virtual uint16_t getItemIndex() { return 0; }
     /**
      * Number of items in the list for `ItemList`
      */

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -138,7 +138,7 @@ class MenuItem {
     /**
      * Current index of list for `ItemList`
      */
-    virtual void setItemIndex(uint8_t itemIndex){};
+    virtual void setItemIndex(uint16_t itemIndex){};
 
     /**
      * Operators

--- a/test/LcdMenu.cpp
+++ b/test/LcdMenu.cpp
@@ -14,7 +14,7 @@
 #define ITEM_LIST_INDEX 99
 
 void commandCallback() {}
-void toggleCallback(uint8_t) {}
+void toggleCallback(uint16_t) {}
 
 MAIN_MENU(ITEM_INPUT("Random", NULL), ITEM_INPUT("Connect", NULL),
           ITEM_BASIC("Settings"), ITEM_COMMAND("Backlight", commandCallback),


### PR DESCRIPTION
- Changed the parameter type of `toggleBacklight` function in `Callbacks.ino` from `uint8_t` to `uint16_t`.
- Changed the parameter type of `callback` function in `IntFloatValues.ino` from `uint8_t` to `uint16_t`.
- Changed the parameter types of `colorsCallback` and `numsCallback` functions in `List.ino` from `uint8_t` to `uint16_t`.
- Updated the typedefs in `Constants.h` for callback functions with integer parameters.
- Updated the return types of `getItemIndex()` functions in `ItemList.h` and `ItemProgress.h` classes from `uint8_t` to `uint16_t`.

This commit updates callback function parameter types and related definitions.

fixes #125