### PR TITLE
[chore] Improved Debug Logging

### DIFF
--- a/.scripts/pio_config.py
+++ b/.scripts/pio_config.py
@@ -1,0 +1,8 @@
+import os
+
+from SCons.Script import Import
+
+Import("env")
+
+if os.getenv("LOCAL_BUILD"):
+    env.Append(CPPDEFINES=["DEBUG"])

--- a/examples/RTOS/RTOS.ino
+++ b/examples/RTOS/RTOS.ino
@@ -19,17 +19,17 @@ bool relay1State, relay2State, relay3State;
 
 // Relay 1 Toggle
 void toggleRelay1(uint16_t isOn) {
-    printCmd(F("relay1State"));
+    printLog(F("relay1State"));
 }
 
 // Relay 2 Toggle
 void toggleRelay2(uint16_t isOn) {
-    printCmd(F("relay2State"));
+    printLog(F("relay2State"));
 }
 
 // Relay 3 Toggle
 void toggleRelay3(uint16_t isOn) {
-    printCmd(F("relay3State"));
+    printLog(F("relay3State"));
 }
 
 LiquidCrystal_I2C lcd(0x27, LCD_COLS, LCD_ROWS);

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,7 @@
 platform = atmelavr
 board = uno
 framework = arduino
+extra_scripts = pre:.scripts/pio_config.py
 lib_deps = 
 	marcoschwartz/LiquidCrystal_I2C@^1.1.4
 	arduino-libraries/LiquidCrystal @ ^1.0.7

--- a/src/ItemCommand.h
+++ b/src/ItemCommand.h
@@ -56,6 +56,7 @@ class ItemCommand : public MenuItem {
         if (callback != NULL) {
             callback();
         }
+        printLog(F("ItemCommand::enter"), text);
         return true;
     };
 };

--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -175,6 +175,7 @@ class ItemInput : public MenuItem {
         display->setEditModeEnabled(true);
         display->resetBlinker(constrainBlinkerPosition(display, strlen(text) + 2 + cursor - view));
         display->drawBlinker();
+        printLog(F("ItemInput::enterEditMode"), value);
         return true;
     };
     bool back(Context& context) {
@@ -191,6 +192,7 @@ class ItemInput : public MenuItem {
         if (callback != NULL) {
             callback(value);
         }
+        printLog(F("ItemInput::exitEditMode"), value);
         return true;
     };
     bool left(Context& context) {
@@ -208,7 +210,7 @@ class ItemInput : public MenuItem {
         }
         display->resetBlinker(constrainBlinkerPosition(display, display->getBlinkerPosition() - 1));
         // Log
-        printCmd(F("LEFT"), value[display->getBlinkerPosition() - (strlen(text) + 2)]);
+        printLog(F("ItemInput::left"), value);
         return true;
     };
     bool right(Context& context) {
@@ -227,7 +229,7 @@ class ItemInput : public MenuItem {
         }
         display->resetBlinker(constrainBlinkerPosition(display, display->getBlinkerPosition() + 1));
         // Log
-        printCmd(F("RIGHT"), value[display->getBlinkerPosition() - (strlen(text) + 2)]);
+        printLog(F("ItemInput::right"), value);
         return true;
     };
     /**
@@ -246,7 +248,7 @@ class ItemInput : public MenuItem {
             return true;
         }
         remove(value, cursor - 1, 1);
-        printCmd(F("BACKSPACE"), value);
+        printLog(F("ItemInput::backspace"), value);
         cursor--;
         if (cursor < view) {
             view--;
@@ -288,7 +290,7 @@ class ItemInput : public MenuItem {
         MenuItem::draw(display);
         display->resetBlinker(constrainBlinkerPosition(display, display->getBlinkerPosition() + 1));
         // Log
-        printCmd(F("TYPE-CHAR"), character);
+        printLog(F("ItemInput::typeChar"), character);
         return true;
     }
     /**
@@ -304,7 +306,7 @@ class ItemInput : public MenuItem {
         //
         value = (char*)"";
         // Log
-        printCmd(F("CLEAR"), value);
+        printLog(F("ItemInput::clear"), value);
         //
         // update blinker position
         //

--- a/src/ItemInputCharset.h
+++ b/src/ItemInputCharset.h
@@ -79,7 +79,6 @@ class ItemInputCharset : public ItemInput {
             concat(value, charset[charsetPosition], buf);
             value = buf;
         }
-        printCmd(F("CHARSET"), value);
         stopCharsetEditMode(display);
         ItemInput::right(context);
         return true;
@@ -129,6 +128,7 @@ class ItemInputCharset : public ItemInput {
         }
         charsetPosition = (charsetPosition + 1) % charsetSize;
         display->drawChar(charset[charsetPosition]);
+        printLog(F("ItemInputCharset::down"), charset[charsetPosition]);
         return true;
     }
 
@@ -142,6 +142,7 @@ class ItemInputCharset : public ItemInput {
         }
         charsetPosition = constrain(charsetPosition - 1, 0, charsetSize);
         display->drawChar(charset[charsetPosition]);
+        printLog(F("ItemInputCharset::up"), charset[charsetPosition]);
         return true;
     }
 };

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -3,23 +3,23 @@
  *
  * # ItemList
  *
- * This item type indicates that the current item is a **list**.
+ * This item type represents a **list**.
  *
  * ### Functionality
- * - `left()`: cycles down the list
- * - `right()`: cycles up the list. This function can be used alone with a
- * single button. Once the menu reaches the end of the list, it automatically
- * starts back from the beginning.
- * - `enter()`: invokes the command *(callback)* bound to this item.
+ * - `down()`: cycles down the list.
+ * - `up()`: cycles up the list. This function can be used with a single button.
+ *           Once the menu reaches the end of the list, it automatically
+ *           starts back from the beginning.
+ * - `enter()`: invokes the command (callback) bound to this item.
  *
  * ### Usage
  * This item can be used for other primitive data types; you just need to pass
- * it as a string, then parse the result to the desired datatype.
+ * them as strings, then parse the result to the desired datatype.
  *
  * ### Parameters
- * @param key: key of the items
- * @param items: array of items to display
- * @param itemCount: number of items in `items`
+ * @param key: key of the item.
+ * @param items: array of items to display.
+ * @param itemCount: number of items in `items`.
  * @param callback: reference to a callback function that will be invoked
  * when the user selects an item from the list.
  */
@@ -85,6 +85,15 @@ class ItemList : public MenuItem {
      */
     String* getItems() { return items; }
 
+    /**
+     * @brief Returns the value of the currently selected item.
+     *
+     * @return The value of the currently selected item.
+     */
+    char* getValue() {
+        return (char*)items[itemIndex].c_str();
+    }
+
   protected:
     void draw(DisplayInterface* display, uint8_t row) override {
         uint8_t maxCols = display->getMaxCols();
@@ -110,6 +119,7 @@ class ItemList : public MenuItem {
             return false;
         }
         display->setEditModeEnabled(true);
+        printLog(F("ItemList::enterEditMode"), getValue());
         return true;
     };
 
@@ -122,6 +132,7 @@ class ItemList : public MenuItem {
         if (callback != NULL) {
             callback(itemIndex);
         }
+        printLog(F("ItemList::exitEditMode"), getValue());
         return true;
     };
 
@@ -133,9 +144,9 @@ class ItemList : public MenuItem {
         uint8_t previousIndex = itemIndex;
         itemIndex = constrain(itemIndex - 1, 0, (uint16_t)(itemCount)-1);
         if (previousIndex != itemIndex) {
-            printCmd(F("LEFT"), items[itemIndex].c_str());
             MenuItem::draw(display);
         }
+        printLog(F("ItemList::down"), getValue());
         return true;
     };
 
@@ -147,9 +158,9 @@ class ItemList : public MenuItem {
         uint8_t previousIndex = itemIndex;
         itemIndex = constrain((itemIndex + 1) % itemCount, 0, (uint16_t)(itemCount)-1);
         if (previousIndex != itemIndex) {
-            printCmd(F("RIGHT"), items[itemIndex].c_str());
             MenuItem::draw(display);
         }
+        printLog(F("ItemList::up"), getValue());
         return true;
     };
 };

--- a/src/ItemProgress.h
+++ b/src/ItemProgress.h
@@ -54,6 +54,7 @@ class ItemProgress : public MenuItem {
             return;
         }
         progress += stepLength;
+        printLog(F("ItemProgress::increment"), getValue());
     }
 
     /**
@@ -64,6 +65,7 @@ class ItemProgress : public MenuItem {
             return;
         }
         progress -= stepLength;
+        printLog(F("ItemProgress::decrement"), getValue());
     }
 
     /**
@@ -127,6 +129,7 @@ class ItemProgress : public MenuItem {
             return false;
         }
         display->setEditModeEnabled(true);
+        printLog(F("ItemProgress::enterEditMode"), getValue());
         return true;
     };
 
@@ -139,6 +142,7 @@ class ItemProgress : public MenuItem {
         if (callback != NULL) {
             callback(progress);
         }
+        printLog(F("ItemProgress::exitEditMode"), getValue());
         return true;
     };
 
@@ -150,7 +154,6 @@ class ItemProgress : public MenuItem {
         uint16_t oldProgress = progress;
         decrement();
         if (progress != oldProgress) {
-            printCmd(F("LEFT"), getValue());
             MenuItem::draw(display);
         }
         return true;
@@ -164,7 +167,6 @@ class ItemProgress : public MenuItem {
         uint16_t oldProgress = progress;
         increment();
         if (progress != oldProgress) {
-            printCmd(F("RIGHT"), getValue());
             MenuItem::draw(display);
         }
         return true;

--- a/src/ItemSubMenu.h
+++ b/src/ItemSubMenu.h
@@ -34,7 +34,7 @@ class ItemSubMenu : public MenuItem {
      * Open next screen.
      */
     bool enter(Context& context) {
-        printCmd(F("Opening screen..."));
+        printLog(F("ItemSubMenu::enter"), text);
         screen->setParent(context.menu->getScreen());
         context.menu->setScreen(screen);
         return true;

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -94,6 +94,7 @@ class ItemToggle : public MenuItem {
         enabled = !enabled;
         if (callback != NULL) {
             callback(enabled);
+            printLog(F("ItemToggle::toggle"), enabled ? textOn : textOff);
         }
         MenuItem::draw(context.display);
         return true;

--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -75,6 +75,11 @@ class LcdMenu {
      * @param screen the new screen to display
      */
     void setScreen(MenuScreen* screen);
+    /**
+     * @brief Process the input character.
+     * @param c the input character
+     * @return `true` if the input was processed successfully
+     */
     bool process(const unsigned char c);
     /**
      * @brief Reset current screen to initial state.
@@ -107,5 +112,8 @@ class LcdMenu {
      * @return `MenuItem` item at `position`
      */
     MenuItem* getItemAt(uint8_t position);
+    /**
+     * @brief Refresh the current screen.
+     */
     void refresh();
 };

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -4,5 +4,6 @@ bool MenuScreen::back(MenuItem::Context context) {
     if (parent != NULL) {
         context.menu->setScreen(parent);
     }
+    printLog(F("MenuScreen::back"));
     return true;
 }

--- a/src/MenuScreen.h
+++ b/src/MenuScreen.h
@@ -162,6 +162,7 @@ class MenuScreen {
      */
     bool up(MenuItem::Context context) {
         if (cursor == 0) {
+            printLog(F("MenuScreen:up"), cursor);
             return false;
         }
         DisplayInterface* display = context.display;
@@ -172,6 +173,7 @@ class MenuScreen {
         } else {
             display->moveCursor(cursor - view);
         }
+        printLog(F("MenuScreen:up"), cursor);
         return true;
     }
     /**
@@ -180,6 +182,7 @@ class MenuScreen {
      */
     bool down(MenuItem::Context context) {
         if (cursor == itemsCount() - 1) {
+            printLog(F("MenuScreen:down"), cursor);
             return false;
         }
         DisplayInterface* display = context.display;
@@ -190,6 +193,7 @@ class MenuScreen {
         } else {
             display->moveCursor(cursor - view);
         }
+        printLog(F("MenuScreen:down"), cursor);
         return true;
     }
     /**
@@ -198,7 +202,9 @@ class MenuScreen {
      * Navigates up once.
      */
     bool back(MenuItem::Context context);
-
+    /**
+     * @brief Reset the screen to initial state.
+     */
     void reset(DisplayInterface* display) {
         cursor = 0;
         view = 0;

--- a/src/display/LiquidCrystalAdapter.h
+++ b/src/display/LiquidCrystalAdapter.h
@@ -94,8 +94,6 @@ class LiquidCrystalAdapter : public DisplayInterface {
         lcd->setCursor(blinkerPosition, cursorRow);
         lcd->print(c);
         lcd->setCursor(blinkerPosition, cursorRow);  // Move back
-        // Log
-        printCmd(F("DRAW-CHAR"), c);
         return true;
     }
 
@@ -103,7 +101,7 @@ class LiquidCrystalAdapter : public DisplayInterface {
         if (millis() != startTime + DISPLAY_TIMEOUT) {
             return;
         }
-        printCmd(F("TIMEOUT"));
+        printLog(F("TIMEOUT"));
         lcd->noDisplay();
     }
 

--- a/src/display/LiquidCrystal_I2CAdapter.h
+++ b/src/display/LiquidCrystal_I2CAdapter.h
@@ -96,8 +96,6 @@ class LiquidCrystal_I2CAdapter : public DisplayInterface {
         lcd->setCursor(blinkerPosition, cursorRow);
         lcd->print(c);
         lcd->setCursor(blinkerPosition, cursorRow);  // Move back
-        // Log
-        printCmd(F("DRAW-CHAR"), c);
         return true;
     }
 
@@ -105,7 +103,7 @@ class LiquidCrystal_I2CAdapter : public DisplayInterface {
         if (millis() != startTime + DISPLAY_TIMEOUT) {
             return;
         }
-        printCmd(F("TIMEOUT"));
+        printLog(F("LiquidCrystal_I2CAdapter::timeout"));
         lcd->noDisplay();
         lcd->noBacklight();
     }

--- a/src/input/KeyboardAdapter.h
+++ b/src/input/KeyboardAdapter.h
@@ -133,11 +133,11 @@ class KeyboardAdapter : public InputInterface {
     void handleIdle() {
         switch (lastChar) {
             case CR:  // Received single `\r`
-                printCmd(F("Call ENTER from idle"));
+                printLog(F("Call ENTER from idle"));
                 menu->process(ENTER);
                 break;
             case ESC:  // Received single `ESC`
-                printCmd(F("Call BACK from idle"));
+                printLog(F("Call BACK from idle"));
                 menu->process(BACK);
                 break;
         }
@@ -152,11 +152,11 @@ class KeyboardAdapter : public InputInterface {
                 switch (command) {
                     case BS:   // 8. On Win
                     case DEL:  // 127. On Mac
-                        printCmd(F("Call BACKSPACE"));
+                        printLog(F("Call BACKSPACE"));
                         menu->process(BACKSPACE);
                         break;
                     case LF:  // 10, \n
-                        printCmd(F("Call ENTER"));
+                        printLog(F("Call ENTER"));
                         menu->process(ENTER);
                         break;
                     case CR:  // 13, \r
@@ -166,7 +166,7 @@ class KeyboardAdapter : public InputInterface {
                         codeSet = CodeSet::C1;
                         break;
                     default:
-                        printCmd(F("Call default"), (uint8_t)command);
+                        printLog(F("Call default"), (uint8_t)command);
                         menu->process(command);
                         break;
                 }
@@ -186,42 +186,42 @@ class KeyboardAdapter : public InputInterface {
                 if (command >= C2_CSI_TERMINAL_MIN && command <= C2_CSI_TERMINAL_MAX) {
                     switch (command) {
                         case 'A':
-                            printCmd(F("Call UP"));
+                            printLog(F("Call UP"));
                             menu->process(UP);
                             break;
                         case 'B':
-                            printCmd(F("Call DOWN"));
+                            printLog(F("Call DOWN"));
                             menu->process(DOWN);
                             break;
                         case 'C':
-                            printCmd(F("Call RIGHT"));
+                            printLog(F("Call RIGHT"));
                             menu->process(RIGHT);
                             break;
                         case 'D':
-                            printCmd(F("Call LEFT"));
+                            printLog(F("Call LEFT"));
                             menu->process(LEFT);
                             break;
                         case 'F':
-                            printCmd(F("End"));
+                            printLog(F("End"));
                             break;
                         case 'H':
-                            printCmd(F("Home"));
+                            printLog(F("Home"));
                             break;
                         case '~':
                             if (csiBufferCursor > 0) {
                                 switch (csiBuffer[0] - '0') {
                                     case 2:  // Insert
-                                        printCmd(F("Insert"));
+                                        printLog(F("Insert"));
                                         break;
                                     case 3:  // Delete
-                                        printCmd(F("Call CLEAR"));
+                                        printLog(F("Call CLEAR"));
                                         menu->process(CLEAR);
                                         break;
                                     case 5:  // PgUp
-                                        printCmd(F("PgUp"));
+                                        printLog(F("PgUp"));
                                         break;
                                     case 6:  // PgDn
-                                        printCmd(F("PgDn"));
+                                        printLog(F("PgDn"));
                                         break;
                                 }
                             }
@@ -251,7 +251,7 @@ class KeyboardAdapter : public InputInterface {
             return;
         }
         unsigned char command = stream->read();
-        printCmd(F("INPUT"), (uint8_t)command);
+        printLog(F("KEY"), command);
         handleReceived(command);
     }
 };

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -51,34 +51,34 @@ inline float mapProgress(uint16_t progress, float minValue, float maxValue) {
            minValue;
 }
 
-inline void printCmd(const __FlashStringHelper* command) {
+inline void printLog(const __FlashStringHelper* command) {
 #ifdef DEBUG
-    Serial.print(F("#CMD# "));
+    Serial.print(F("#LOG# "));
     Serial.println(command);
 #endif
 }
 
-inline void printCmd(const __FlashStringHelper* command, const char value) {
+inline void printLog(const __FlashStringHelper* command, const char value) {
 #ifdef DEBUG
-    Serial.print(F("#CMD# "));
+    Serial.print(F("#LOG# "));
     Serial.print(command);
     Serial.print(F("="));
     Serial.println(value);
 #endif
 }
 
-inline void printCmd(const __FlashStringHelper* command, const uint8_t value) {
+inline void printLog(const __FlashStringHelper* command, const uint8_t value) {
 #ifdef DEBUG
-    Serial.print(F("#CMD# "));
+    Serial.print(F("#LOG# "));
     Serial.print(command);
     Serial.print(F("="));
     Serial.println(value, DEC);
 #endif
 }
 
-inline void printCmd(const __FlashStringHelper* command, const char* value) {
+inline void printLog(const __FlashStringHelper* command, const char* value) {
 #ifdef DEBUG
-    Serial.print(F("#CMD# "));
+    Serial.print(F("#LOG# "));
     Serial.print(command);
     Serial.print(F("="));
     Serial.println(value);


### PR DESCRIPTION
Fixes #217

- Replaced `printCmd` with `printLog` for better debug messages
- Added debug flag in `platformio.ini` for debugging purposes

### Sample

```bash
#LOG# MenuScreen:down=1
#LOG# MenuScreen:down=2
#LOG# MenuScreen:down=3
#LOG# MenuScreen:down=3
#LOG# MenuScreen:up=2
#LOG# MenuScreen:up=1
#LOG# MenuScreen:up=0
#LOG# ItemSubMenu::enter=Set user
#LOG# MenuScreen:down=1
#LOG# MenuScreen:up=0
#LOG# ItemInput::enterEditMode=
#LOG# ItemInputCharset::down=A
#LOG# ItemInputCharset::down=B
#LOG# ItemInputCharset::down=C
#LOG# ItemInputCharset::up=B
#LOG# ItemInput::right=B
#LOG# ItemInputCharset::down=A
#LOG# ItemInput::right=BA
#LOG# ItemInputCharset::down=A
#LOG# ItemInputCharset::down=B
#LOG# ItemInputCharset::down=C
#LOG# ItemInputCharset::down=D
#LOG# ItemInput::right=BAD
# BAD
#LOG# ItemInput::exitEditMode=BAD
#LOG# MenuScreen:down=1
#LOG# ItemCommand::enter=Clear
#LOG# MenuScreen:up=0
#LOG# MenuScreen:down=1
#LOG# ItemCommand::enter=Clear
#LOG# ItemCommand::enter=Clear
```