### PR TITLE
Feature/refactor items

### DIFF
--- a/docs/classes.puml
+++ b/docs/classes.puml
@@ -2,57 +2,97 @@
 ' https://www.plantuml.com/plantuml/uml/
 
 hide empty members
+left to right direction
+
+class InputInterface {
+    virtual void observe()
+}
+
+class DisplayInterface {
+    #uint8_t maxCols
+    #uint8_t maxRows
+    #uint8_t cursorRow
+    #uint8_t blinkerPosition
+    +bool isEditModeEnabled
+    +virtual void begin()
+    +uint8_t getMaxRows() const
+    +uint8_t getMaxCols() const
+    +virtual void clear()
+    +virtual void setBacklight(bool enabled)
+    +virtual void drawItem(uint8_t row, const char* text)
+    +virtual void drawItem(uint8_t row, const char* text, char separator, char* value)
+    +virtual void clearCursor()
+    +virtual void drawCursor()
+    +virtual void moveCursor(uint8_t newCursorRow)
+    +void setEditModeEnabled(bool enabled)
+    +bool getEditModeEnabled()
+    +uint8_t getCursorRow() const
+    +virtual void clearBlinker()
+    +virtual void drawBlinker()
+    +virtual void resetBlinker(uint8_t blinkerPosition)
+    +uint8_t getBlinkerPosition() const
+    +virtual bool drawChar(char c)
+    +virtual void clearUpIndicator()
+    +virtual void drawUpIndicator()
+    +virtual void clearDownIndicator()
+    +virtual void drawDownIndicator()
+    +virtual void restartTimer()
+}
 
 class LcdMenu {
-    +virtual bool process(char c)
+    -bool enabled
+    +DisplayInterface* getDisplay()
+    +MenuScreen* getScreen()
+    +void setScreen(MenuScreen* screen)
+    +uint8_t getCursor()
+    +MenuItem* getItemAt(uint8_t position)
+    +void setCursor(uint8_t cursor)
+    +bool process(const unsigned char c)
+    +void reset()
+    +void hide()
+    +void show()
+    +void refresh()
+
 }
 
 class MenuScreen {
-    #virtual bool process(Context context)
-    #virtual bool up()
-    #virtual bool down()
-    #virtual bool back()
-}
+    -uint8_t cursor
+    -uint8_t view
+    +void setParent(MenuScreen* parent)
+    +MenuItem* operator[](const uint8_t position)
+    +uint8_t getCursor()
+    +MenuItem* getItemAt(uint8_t position)
+    #void setCursor(DisplayInterface* display, uint8_t position)
+    #bool process(LcdMenu* menu, const unsigned char command)
+    #void draw(DisplayInterface* display)
+    #bool up(DisplayInterface* display)
+    #bool down(DisplayInterface* display)
+    #bool back(LcdMenu* menu)
+    #uint8_t itemsCount()
 
-struct MenuItem::Context {
-    LcdMenu* menu;
-    DisplayInterface* display;
-    const unsigned char command;
 }
 
 class MenuItem {
-    #virtual bool process(Context context)
+    #const char* text
+    +const char* getText()
+    +void setText(const char* text)
+    #virtual bool process(LcdMenu* menu, const unsigned char command)
+    #const void draw(DisplayInterface* display)
+    #virtual void draw(DisplayInterface* display, uint8_t row)
 }
 
-class ItemCommand {
-    #bool process(Context context) override
-    #bool enter(Context context)
-}
+InputInterface -r-> "1" LcdMenu : menu
+LcdMenu -r-> "1" DisplayInterface : display
+LcdMenu -d-> "1" MenuScreen : screen
+MenuScreen -d-> "1..*" MenuItem : items
+MenuScreen --> "0..1" MenuScreen : parent
 
-class ItemList {
-    #bool process(Context context) override
-    #bool up(Context context)
-    #bool down(Context context)
-    #bool enter(Context context)
-    #bool back(Context context)
-}
+LcdMenu::process .. MenuScreen::process
+LcdMenu::getCursor .. MenuScreen::getCursor
+LcdMenu::setCursor .. MenuScreen::setCursor
+LcdMenu::getItemAt .. MenuScreen::getItemAt
 
-class ItemInput {
-    #bool process(Context context) override
-    #bool up(Context context)
-    #bool down(Context context)
-    #bool enter(Context context)
-    #bool back(Context context)
-    #bool left(Context context)
-    #bool right(Context context)
-    #bool backspace(Context context)
-    #bool typeChar(Context context)
-    #bool clear(Context context)
-}
+MenuScreen::process .. MenuItem::process
+MenuScreen::draw .. MenuItem::draw
 
-LcdMenu -r-> MenuScreen
-MenuScreen -r-> MenuItem
-ItemCommand -u-|> MenuItem
-ItemList -u-|> MenuItem
-ItemInput -u-|> MenuItem
 @enduml

--- a/docs/items.puml
+++ b/docs/items.puml
@@ -1,0 +1,93 @@
+@startuml
+' https://www.plantuml.com/plantuml/uml/
+
+hide empty members
+left to right direction
+
+class MenuItem {
+    #const char* text
+    +const char* getText()
+    +void setText(const char* text)
+    #virtual bool process(LcdMenu* menu, const unsigned char command)
+    #const void draw(DisplayInterface* display)
+    #virtual void draw(DisplayInterface* display, uint8_t row)
+}
+
+class ItemBack {
+    #bool process(LcdMenu* menu, const unsigned char command) override
+    ..
+    #void changeScreen(LcdMenu* menu)
+}
+
+class ItemSubMenu {
+    #bool process(LcdMenu* menu, const unsigned char command) override
+    ..
+    #void changeScreen(LcdMenu* menu)
+}
+
+class ItemToggle {
+    #bool process(LcdMenu* menu, const unsigned char command) override
+    ..
+    #void toggle(DisplayInterface* display)
+}
+
+class ItemCommand {
+    #bool process(LcdMenu* menu, const unsigned char command) override
+    ..
+    #void executeCommand()
+}
+
+class ItemInput {
+    #bool process(LcdMenu* menu, const unsigned char command) override
+    ..
+    #void up(DisplayInterface* display)
+    #void down(DisplayInterface* display)
+    #void enter(DisplayInterface* display)
+    #void back(DisplayInterface* display)
+    #void left(DisplayInterface* display)
+    #void right(DisplayInterface* display)
+    #void backspace(DisplayInterface* display)
+    #void typeChar(DisplayInterface* display, const unsigned char command)
+    #void clear(DisplayInterface* display)
+}
+
+class ItemInputCharset {
+    #bool process(LcdMenu* menu, const unsigned char command) override
+    ..
+    #void initCharEdit()
+    #void abortCharEdit(DisplayInterface* display)
+    #void commitCharEdit(DisplayInterface* display)
+    #void showNextChar(DisplayInterface* display)
+    #void showPreviousChar(DisplayInterface* display)
+}
+
+class ItemList {
+    #bool process(LcdMenu* menu, const unsigned char command) override
+    ..
+    #void selectPrevious(DisplayInterface* display)
+    #void selectNext(DisplayInterface* display)
+}
+
+class ItemProgress {
+    #bool process(LcdMenu* menu, const unsigned char command) override
+    ..
+    +void increment()
+    +void decrement()
+}
+
+class EditMode as "???" {
+}
+
+note bottom of EditMode : Someone who holds edit mode
+
+ItemBack -u-|> MenuItem
+ItemSubMenu -u-|> MenuItem
+ItemToggle -u-|> MenuItem
+ItemCommand -u-|> MenuItem
+EditMode -u-|> MenuItem
+ItemList -u-|> EditMode
+ItemProgress -u-|> EditMode
+ItemInput -u-|> EditMode
+ItemInputCharset -u-|> ItemInput
+
+@enduml

--- a/src/ItemBack.h
+++ b/src/ItemBack.h
@@ -25,11 +25,17 @@ class ItemBack : public MenuItem {
     ItemBack(const char* text = "..") : MenuItem(text) {}
 
   protected:
-    bool process(Context& context) override {
-        switch (context.command) {
-            case ENTER: context.menu->process(BACK); return true;
-            default: return false;
+    bool process(LcdMenu* menu, const unsigned char command) override {
+        switch (command) {
+            case ENTER:
+                changeScreen(menu);
+                return true;
+            default:
+                return false;
         }
+    }
+    void changeScreen(LcdMenu* menu) {
+        menu->process(BACK);
     }
 };
 

--- a/src/ItemCommand.h
+++ b/src/ItemCommand.h
@@ -46,19 +46,21 @@ class ItemCommand : public MenuItem {
     void setCallBack(fptr callback) { this->callback = callback; };
 
   protected:
-    bool process(Context& context) override {
-        switch (context.command) {
-            case ENTER: return enter(context);
-            default: return false;
+    bool process(LcdMenu* menu, const unsigned char command) override {
+        switch (command) {
+            case ENTER:
+                executeCommand();
+                return true;
+            default:
+                return false;
         }
     }
-    bool enter(Context& context) {
+    void executeCommand() {
         if (callback != NULL) {
             callback();
         }
         printLog(F("ItemCommand::enter"), text);
-        return true;
-    };
+    }
 };
 
 #define ITEM_COMMAND(...) (new ItemCommand(__VA_ARGS__))

--- a/src/ItemInputCharset.h
+++ b/src/ItemInputCharset.h
@@ -2,22 +2,91 @@
 #define ItemInputCharset_H
 
 #include "ItemInput.h"
+#include "LcdMenu.h"
 #include <utils/utils.h>
 
 class ItemInputCharset : public ItemInput {
   private:
     const char* charset;
-    const uint8_t charsetSize;
     // Active index of the charset
     int8_t charsetPosition = -1;
-    bool charEditMode = false;
+    bool charEdit = false;
 
+  public:
+    ItemInputCharset(const char* text, char* value, const char* charset, fptrStr callback)
+        : ItemInput(text, value, callback), charset(charset) {}
+
+    ItemInputCharset(const char* text, const char* charset, fptrStr callback)
+        : ItemInputCharset(text, (char*)"", charset, callback) {}
+
+  protected:
+    bool process(LcdMenu* menu, const unsigned char command) override {
+        DisplayInterface* display = menu->getDisplay();
+        if (display->getEditModeEnabled()) {
+            switch (command) {
+                case ENTER:
+                    if (charEdit) {
+                        commitCharEdit(display);
+                    }
+                    return true;
+                case BACK:
+                    if (charEdit) {
+                        abortCharEdit(display);
+                    } else {
+                        ItemInput::back(display);
+                    }
+                    return true;
+                case UP:
+                    if (!charEdit) {
+                        initCharEdit();
+                    }
+                    showPreviousChar(display);
+                    printLog(F("ItemInputCharset::up"), charset[charsetPosition]);
+                    return true;
+                case DOWN:
+                    if (!charEdit) {
+                        initCharEdit();
+                    }
+                    showNextChar(display);
+                    printLog(F("ItemInputCharset::down"), charset[charsetPosition]);
+                    return true;
+                case LEFT:
+                    if (charEdit) {
+                        abortCharEdit(display);
+                    }
+                    ItemInput::left(display);
+                    return true;
+                case RIGHT:
+                    if (charEdit) {
+                        abortCharEdit(display);
+                    }
+                    ItemInput::right(display);
+                    return true;
+                case BACKSPACE:
+                    ItemInput::backspace(display);
+                    return true;
+                case CLEAR:
+                    ItemInput::clear(display);
+                    return true;
+                default:
+                    return false;
+            }
+        } else {
+            switch (command) {
+                case ENTER:
+                    ItemInput::enter(display);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
     /**
      * @brief Initialize `char edit mode`.
-     * Set `charEditMode` flag and search for currently selected char in charset.
+     * Set `charEdit` flag and search for currently selected char in charset.
      */
-    void initCharsetEditMode() {
-        charEditMode = true;
+    void initCharEdit() {
+        charEdit = true;
         if (cursor < strlen(value)) {
             char* e = strchr(charset, value[cursor]);
             if (e != NULL) {
@@ -27,50 +96,19 @@ class ItemInputCharset : public ItemInput {
         }
         charsetPosition = -1;
     }
-
     /**
-     * @brief Stop `char edit mode`.
-     * Unset `charEditMode` flag and draw actual char from `value`.
+     * @brief Stop `char edit mode` and abort all mde changes.
+     * Unset `charEdit` flag and draw actual char from `value`.
      */
-    void stopCharsetEditMode(DisplayInterface* display) {
-        charEditMode = false;
+    void abortCharEdit(DisplayInterface* display) {
+        charEdit = false;
         if (cursor < strlen(value)) {
             display->drawChar(value[cursor]);
         } else {
             display->drawChar(' ');
         }
     }
-
-  public:
-    ItemInputCharset(const char* text, char* value, const char* charset, fptrStr callback)
-        : ItemInput(text, value, callback), charset(charset), charsetSize(strlen(charset)) {}
-    ItemInputCharset(const char* text, const char* charset, fptrStr callback)
-        : ItemInputCharset(text, (char*)"", charset, callback) {}
-
-  protected:
-    bool process(Context& context) override {
-        const unsigned char c = context.command;
-        switch (c) {
-            case ENTER: return enter(context);
-            case BACK: return back(context);
-            case UP: return up(context);
-            case DOWN: return down(context);
-            case LEFT: return left(context);
-            case RIGHT: return right(context);
-            case BACKSPACE: return ItemInput::backspace(context);
-            case CLEAR: return ItemInput::clear(context);
-            default: return false;
-        }
-    }
-
-    bool enter(Context& context) {
-        DisplayInterface* display = context.display;
-        if (!display->getEditModeEnabled()) {
-            return ItemInput::enter(context);
-        }
-        if (!charEditMode) {
-            return true;
-        }
+    void commitCharEdit(DisplayInterface* display) {
         uint8_t length = strlen(value);
         if (cursor < length) {
             value[cursor] = charset[charsetPosition];
@@ -79,71 +117,20 @@ class ItemInputCharset : public ItemInput {
             concat(value, charset[charsetPosition], buf);
             value = buf;
         }
-        stopCharsetEditMode(display);
-        ItemInput::right(context);
-        return true;
+        abortCharEdit(display);
+        ItemInput::right(display);
     }
-
-    bool back(Context& context) {
-        DisplayInterface* display = context.display;
-        if (!display->getEditModeEnabled()) {
-            return false;
+    void showNextChar(DisplayInterface* display) {
+        if (charset[charsetPosition + 1] == '\0') {
+            charsetPosition = 0;
+        } else {
+            charsetPosition++;
         }
-        if (!charEditMode) {
-            return ItemInput::back(context);
-        }
-        stopCharsetEditMode(display);
-        return true;
-    };
-
-    bool left(Context& context) {
-        DisplayInterface* display = context.display;
-        if (!display->getEditModeEnabled()) {
-            return false;
-        }
-        if (charEditMode) {
-            stopCharsetEditMode(display);
-        }
-        return ItemInput::left(context);
-    }
-
-    bool right(Context& context) {
-        DisplayInterface* display = context.display;
-        if (!display->getEditModeEnabled()) {
-            return false;
-        }
-        if (charEditMode) {
-            stopCharsetEditMode(display);
-        }
-        return ItemInput::right(context);
-    }
-
-    bool down(Context& context) {
-        DisplayInterface* display = context.display;
-        if (!display->getEditModeEnabled()) {
-            return false;
-        }
-        if (!charEditMode) {
-            initCharsetEditMode();
-        }
-        charsetPosition = (charsetPosition + 1) % charsetSize;
         display->drawChar(charset[charsetPosition]);
-        printLog(F("ItemInputCharset::down"), charset[charsetPosition]);
-        return true;
     }
-
-    bool up(Context& context) {
-        DisplayInterface* display = context.display;
-        if (!display->getEditModeEnabled()) {
-            return false;
-        }
-        if (!charEditMode) {
-            initCharsetEditMode();
-        }
-        charsetPosition = constrain(charsetPosition - 1, 0, charsetSize);
+    void showPreviousChar(DisplayInterface* display) {
+        charsetPosition = max(charsetPosition - 1, 0);
         display->drawChar(charset[charsetPosition]);
-        printLog(F("ItemInputCharset::up"), charset[charsetPosition]);
-        return true;
     }
 };
 

--- a/src/ItemSubMenu.h
+++ b/src/ItemSubMenu.h
@@ -33,7 +33,7 @@ class ItemSubMenu : public MenuItem {
         }
     }
     void changeScreen(LcdMenu* menu) {
-        printLog(F("ItemSubMenu::enter"), text);
+        printLog(F("ItemSubMenu::changeScreen"), text);
         screen->setParent(menu->getScreen());
         menu->setScreen(screen);
     }

--- a/src/ItemSubMenu.h
+++ b/src/ItemSubMenu.h
@@ -24,20 +24,18 @@ class ItemSubMenu : public MenuItem {
     ItemSubMenu(const char* text, MenuScreen*& screen) : MenuItem(text), screen(screen) {}
 
   protected:
-    bool process(Context& context) {
-        switch (context.command) {
-            case ENTER: return enter(context);
-            default: return false;
+    bool process(LcdMenu* menu, const unsigned char command) {
+        switch (command) {
+            case ENTER:
+                return true;
+            default:
+                return false;
         }
     }
-    /**
-     * Open next screen.
-     */
-    bool enter(Context& context) {
+    void changeScreen(LcdMenu* menu) {
         printLog(F("ItemSubMenu::enter"), text);
-        screen->setParent(context.menu->getScreen());
-        context.menu->setScreen(screen);
-        return true;
+        screen->setParent(menu->getScreen());
+        menu->setScreen(screen);
     }
 };
 

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -9,8 +9,8 @@
 
 #ifndef ItemToggle_H
 #define ItemToggle_H
-#include "MenuItem.h"
 #include "LcdMenu.h"
+#include "MenuItem.h"
 #include <utils/utils.h>
 
 /**

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -10,6 +10,7 @@
 #ifndef ItemToggle_H
 #define ItemToggle_H
 #include "MenuItem.h"
+#include "LcdMenu.h"
 #include <utils/utils.h>
 
 /**

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -84,21 +84,24 @@ class ItemToggle : public MenuItem {
     };
 
   protected:
-    bool process(Context& context) override {
-        switch (context.command) {
-            case ENTER: return enter(context);
-            default: return false;
+    bool process(LcdMenu* menu, const unsigned char command) override {
+        DisplayInterface* display = menu->getDisplay();
+        switch (command) {
+            case ENTER:
+                toggle(display);
+                return true;
+            default:
+                return false;
         }
     };
-    bool enter(Context& context) {
+    void toggle(DisplayInterface* display) {
         enabled = !enabled;
         if (callback != NULL) {
             callback(enabled);
-            printLog(F("ItemToggle::toggle"), enabled ? textOn : textOff);
         }
-        MenuItem::draw(context.display);
-        return true;
-    };
+        printLog(F("ItemToggle::toggle"), enabled ? textOn : textOff);
+        MenuItem::draw(display);
+    }
 };
 
 #define ITEM_TOGGLE(...) (new ItemToggle(__VA_ARGS__))

--- a/src/LcdMenu.cpp
+++ b/src/LcdMenu.cpp
@@ -18,12 +18,11 @@ bool LcdMenu::process(const unsigned char c) {
     if (!enabled) {
         return false;
     }
-    MenuItem::Context context{this, &display, c};
-    return screen->process(context);
+    return screen->process(this, c);
 };
 
 void LcdMenu::reset() {
-    this->screen->reset(&display);
+    this->screen->setCursor(&display, 0);
 }
 
 void LcdMenu::hide() {

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -56,7 +56,7 @@ class MenuItem {
      * Get the text of the item
      * @return `String` - Item's text
      */
-    virtual const char* getText() { return text; }
+    const char* getText() { return text; }
     /**
      * Set the text of the item
      * @param text text to display for the item
@@ -64,11 +64,6 @@ class MenuItem {
     void setText(const char* text) { this->text = text; };
 
   protected:
-    struct Context {
-        LcdMenu* menu;
-        DisplayInterface* display;
-        const unsigned char command;
-    };
     /**
      * @brief Process a command decoded in 1 byte.
      * It can be a printable character or a control command like `ENTER` or `LEFT`.
@@ -79,7 +74,7 @@ class MenuItem {
      * @param context the context of call, contains at least character command (can be a printable character or a control command) and backreference to menu
      * @return true if command was successfully handled by item.
      */
-    virtual bool process(Context& context) { return false; };
+    virtual bool process(LcdMenu* menu, const unsigned char command) { return false; };
     /**
      * @brief Draw this menu item on specified display on current line.
      * @param display the display that should be used for draw

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -53,15 +53,19 @@ class MenuItem {
   public:
     MenuItem(const char* text) : text(text) {}
     /**
-     * Get the text of the item
+     * @brief Get the text of the item
      * @return `String` - Item's text
      */
-    const char* getText() { return text; }
+    const char* getText() {
+        return text;
+    }
     /**
-     * Set the text of the item
+     * @brief Set the text of the item
      * @param text text to display for the item
      */
-    void setText(const char* text) { this->text = text; };
+    void setText(const char* text) {
+        this->text = text;
+    };
 
   protected:
     /**
@@ -71,10 +75,13 @@ class MenuItem {
      * If the parent of item received that handle was ignored it can execute it's own action on this command.
      * Thus, the item always has priority in processing; if it is ignored, it is delegated to the parent element.
      * Behaviour is very similar to Even Bubbling in JavaScript.
-     * @param context the context of call, contains at least character command (can be a printable character or a control command) and backreference to menu
+     * @param menu the owner menu of the item, can be used to retrieve required object, such as `DisplayInterface` or `MenuScreen`
+     * @param command the character command, can be a printable character or a control command
      * @return true if command was successfully handled by item.
      */
-    virtual bool process(LcdMenu* menu, const unsigned char command) { return false; };
+    virtual bool process(LcdMenu* menu, const unsigned char command) {
+        return false;
+    };
     /**
      * @brief Draw this menu item on specified display on current line.
      * @param display the display that should be used for draw

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -1,9 +1,24 @@
 #include "MenuScreen.h"
 
-bool MenuScreen::back(MenuItem::Context context) {
-    if (parent != NULL) {
-        context.menu->setScreen(parent);
+bool MenuScreen::process(LcdMenu* menu, const unsigned char command) {
+    DisplayInterface* display = menu->getDisplay();
+    if (items[cursor]->process(menu, command)) {
+        return true;
     }
-    printLog(F("MenuScreen::back"));
-    return true;
+    switch (command) {
+        case UP:
+            up(display);
+            return true;
+        case DOWN:
+            down(display);
+            return true;
+        case BACK:
+            if (parent != NULL) {
+                menu->setScreen(parent);
+            }
+            printLog(F("MenuScreen::back"));
+            return true;
+        default:
+            return false;
+    }
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -1,7 +1,7 @@
 #ifndef MenuUtils_H
 #define MenuUtils_H
-#include <Arduino.h>
 
+#include <Arduino.h>
 #include "constants.h"
 
 inline void substring(const char* str, uint8_t start, uint8_t size, char* substr) {

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -1,8 +1,8 @@
 #ifndef MenuUtils_H
 #define MenuUtils_H
 
-#include <Arduino.h>
 #include "constants.h"
+#include <Arduino.h>
 
 inline void substring(const char* str, uint8_t start, uint8_t size, char* substr) {
     strncpy(substr, str + start, size);


### PR DESCRIPTION
I tried to rename methods from up/down/left/right into specific for item, something like more 'domain specific':
- `changeScreen` for `ItemBack` and `ItemSubMenu` insted of `enter`.
- `commitCharEdit` for `ItemInputCharset` instead of `enter`.

![image](https://github.com/user-attachments/assets/a91cdd94-7092-4543-88cd-a3fde4a5a19c)

Also signature of `process` simplified and instead of `Context` pass only `LcdMenu` and char.
All required dependencies (display and current screen) can be obtained from menu.

Also true/false result for process method is controlled inside process method. Also simplified repeated if's

Also need somehow separate value update and draw.
