### PR TITLE
Enable jumping to upper bound when lower bound reached

### DIFF
--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -126,7 +126,7 @@ class ItemList : public MenuItem {
 
     void selectPrevious(DisplayInterface* display) {
         uint8_t previousIndex = itemIndex;
-        itemIndex = constrain(itemIndex - 1, 0, itemCount - 1);
+        (int8_t)(itemIndex - 1) < 0 ? itemIndex = itemCount - 1 : itemIndex--;
         if (previousIndex != itemIndex) {
             MenuItem::draw(display);
         }

--- a/test/List.test.yml
+++ b/test/List.test.yml
@@ -24,12 +24,10 @@ steps:
   - simulate: downButton-press
   - wait-serial: "#LOG# ItemList::selectPrevious=12"
   - simulate: upButton-press
-  - wait-serial: "#LOG# ItemList::selectNext=12"
-  - simulate: upButton-press
   - wait-serial: "#LOG# ItemList::selectNext=32"
   - simulate: upButton-press
   - wait-serial: "#LOG# ItemList::selectNext=5"
   - simulate: upButton-press
   - wait-serial: "#LOG# ItemList::selectNext=7"
   - simulate: backButton-press
-  - wait-serial: "#LOG# ItemList::exitEditMode=5"
+  - wait-serial: "#LOG# ItemList::exitEditMode=7"

--- a/test/List.test.yml
+++ b/test/List.test.yml
@@ -20,18 +20,16 @@ steps:
   - simulate: enterButton-press
   - wait-serial: "#LOG# ItemList::enterEditMode=5"
   - simulate: downButton-press
-  - wait-serial: "#LOG# ItemList::selectPrevious=5"
+  - wait-serial: "#LOG# ItemList::selectPrevious=32"
   - simulate: downButton-press
-  - wait-serial: "#LOG# ItemList::selectPrevious=5"
-  - simulate: upButton-press
-  - wait-serial: "#LOG# ItemList::selectNext=7"
-  - simulate: upButton-press
-  - wait-serial: "#LOG# ItemList::selectNext=9"
+  - wait-serial: "#LOG# ItemList::selectPrevious=12"
   - simulate: upButton-press
   - wait-serial: "#LOG# ItemList::selectNext=12"
   - simulate: upButton-press
   - wait-serial: "#LOG# ItemList::selectNext=32"
   - simulate: upButton-press
   - wait-serial: "#LOG# ItemList::selectNext=5"
+  - simulate: upButton-press
+  - wait-serial: "#LOG# ItemList::selectNext=7"
   - simulate: backButton-press
   - wait-serial: "#LOG# ItemList::exitEditMode=5"


### PR DESCRIPTION
Adjust item selection logic to allow jumping from the lower bound to the upper bound when navigating through items.

This enables the user to cycle through the items in both ways using only one action.
