### PR TITLE
Isolate constants to reduce memory footprint

### DIFF
--- a/examples/IntFloatValues/IntFloatValues.ino
+++ b/examples/IntFloatValues/IntFloatValues.ino
@@ -19,7 +19,7 @@ void callback(uint16_t pos);
 
 char* intMapping(uint16_t progress) {
     // Map the progress value to a new range (100 to 200)
-    long mapped = mapProgress(progress, 100L, 200L);
+    long mapped = ItemProgress::mapProgress(progress, 100L, 200L);
 
     // Buffer to store the converted stringV
     static char buffer[10];
@@ -37,7 +37,7 @@ char* intMapping(uint16_t progress) {
 char* floatMapping(uint16_t progress) {
     // Normalize the progress value and map it to the specified floating-point
     // range
-    float floatValue = mapProgress(progress, -1.0f, 1.0f);
+    float floatValue = ItemProgress::mapProgress(progress, -1.0f, 1.0f);
 
     // Buffer to store the converted string
     static char buffer[10];

--- a/src/ItemProgress.h
+++ b/src/ItemProgress.h
@@ -1,6 +1,9 @@
 #ifndef ItemProgress_H
 #define ItemProgress_H
-
+//
+#define MIN_PROGRESS 0
+#define MAX_PROGRESS 1000
+//
 #include "LcdMenu.h"
 #include "MenuItem.h"
 #include <utils/utils.h>
@@ -106,6 +109,33 @@ class ItemProgress : public MenuItem {
             return buf;
         }
         return mapping(progress);
+    }
+
+    /**
+     * @brief Maps the progress value to a new range.
+     *
+     * @param progress The progress value to map.
+     * @param minValue The minimum value of the new range.
+     * @param maxValue The maximum value of the new range.
+     *
+     * @return The mapped value.
+     */
+    static inline long mapProgress(uint16_t progress, long minValue, long maxValue) {
+        return map(progress, MIN_PROGRESS, MAX_PROGRESS, minValue, maxValue);
+    }
+
+    /**
+     * @brief Maps the progress value to a new floating-point range.
+     *
+     * @param progress The progress value to map.
+     * @param minValue The minimum value of the new range.
+     * @param maxValue The maximum value of the new range.
+     *
+     * @return The mapped value.
+     */
+    static inline float mapProgress(uint16_t progress, float minValue, float maxValue) {
+        return static_cast<float>(progress) / MAX_PROGRESS * (maxValue - minValue) +
+               minValue;
     }
 
   protected:

--- a/src/display/LiquidCrystalAdapter.h
+++ b/src/display/LiquidCrystalAdapter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "utils/liquidcrystal.h"
 #include <Arduino.h>
 #include <LiquidCrystal.h>
 #include <utils/constants.h>

--- a/src/display/LiquidCrystal_I2CAdapter.h
+++ b/src/display/LiquidCrystal_I2CAdapter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "utils/liquidcrystal.h"
 #include <Arduino.h>
 #include <LiquidCrystal_I2C.h>
 #include <utils/constants.h>

--- a/src/display/utils/liquidcrystal.h
+++ b/src/display/utils/liquidcrystal.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <Arduino.h>
+//
+#ifndef CURSOR_ICON
+#define CURSOR_ICON 0x7E  // →
+#endif
+#ifndef EDIT_CURSOR_ICON
+#define EDIT_CURSOR_ICON 0x7F  // ←
+#endif
+//
+const byte DOWN_ARROW[8] = {
+    0b00100,  //   *
+    0b00100,  //   *
+    0b00100,  //   *
+    0b00100,  //   *
+    0b00100,  //   *
+    0b10101,  // * * *
+    0b01110,  //  ***
+    0b00100   //   *
+};
+const byte UP_ARROW[8] = {
+    0b00100,  //   *
+    0b01110,  //  ***
+    0b10101,  // * * *
+    0b00100,  //   *
+    0b00100,  //   *
+    0b00100,  //   *
+    0b00100,  //   *
+    0b00100   //   *
+};

--- a/src/input/SimpleRotaryAdapter.h
+++ b/src/input/SimpleRotaryAdapter.h
@@ -1,5 +1,14 @@
 #pragma once
-
+//
+// Rotary encoder configuration
+//
+#ifndef LONG_PRESS_DURATION
+#define LONG_PRESS_DURATION 1000
+#endif
+#ifndef DOUBLE_PRESS_THRESHOLD
+#define DOUBLE_PRESS_THRESHOLD 300
+#endif
+//
 #include "InputInterface.h"
 #include <SimpleRotary.h>
 

--- a/src/utils/constants.h
+++ b/src/utils/constants.h
@@ -17,45 +17,6 @@ typedef char* (*fptrMapping)(uint16_t);
 #define LEFT 131     // >127
 #define CLEAR 132    // >127
 //
-// Rotary encoder configuration
-//
-#ifndef LONG_PRESS_DURATION
-#define LONG_PRESS_DURATION 1000
-#endif
-#ifndef DOUBLE_PRESS_THRESHOLD
-#define DOUBLE_PRESS_THRESHOLD 300
-#endif
-//
-const byte DOWN_ARROW[8] = {
-    0b00100,  //   *
-    0b00100,  //   *
-    0b00100,  //   *
-    0b00100,  //   *
-    0b00100,  //   *
-    0b10101,  // * * *
-    0b01110,  //  ***
-    0b00100   //   *
-};
-const byte UP_ARROW[8] = {
-    0b00100,  //   *
-    0b01110,  //  ***
-    0b10101,  // * * *
-    0b00100,  //   *
-    0b00100,  //   *
-    0b00100,  //   *
-    0b00100,  //   *
-    0b00100   //   *
-};
-//
-#define MIN_PROGRESS 0
-#define MAX_PROGRESS 1000
-//
-#ifndef CURSOR_ICON
-#define CURSOR_ICON 0x7E  // →
-#endif
-#ifndef EDIT_CURSOR_ICON
-#define EDIT_CURSOR_ICON 0x7F  // ←
-#endif
 #ifndef DISPLAY_TIMEOUT
 #define DISPLAY_TIMEOUT 10000  // 10 seconds
 #endif

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -39,18 +39,6 @@ inline void remove(char* str, uint8_t index, uint8_t count) {
     memmove(str + index, str + index + count, len - count - index + 1);
 }
 
-inline long mapProgress(uint16_t progress, long minValue, long maxValue) {
-    // Map the progress value to a new range (minValue to maxValue)
-    return map(progress, MIN_PROGRESS, MAX_PROGRESS, minValue, maxValue);
-}
-
-inline float mapProgress(uint16_t progress, float minValue, float maxValue) {
-    // Normalize the progress value and map it to the specified floating-point
-    // range
-    return static_cast<float>(progress) / MAX_PROGRESS * (maxValue - minValue) +
-           minValue;
-}
-
 inline void printLog(const __FlashStringHelper* command) {
 #ifdef DEBUG
     Serial.print(F("#LOG# "));


### PR DESCRIPTION
- Moved constants from "constants.h" to specific header files
- Updated code references accordingly
