### PR TITLE
Remove `itemIndex` dependency from renderer

### DIFF
--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -129,7 +129,7 @@ class ItemInput : public MenuItem {
     fptrStr getCallbackStr() { return callback; }
 
   protected:
-    void draw(MenuRenderer* renderer, uint8_t itemIndex, uint8_t screenRow) override {
+    void draw(MenuRenderer* renderer, uint8_t screenRow) override {
         uint8_t viewSize = getViewSize(renderer);
         char* vbuf = new char[viewSize + 1];
         substring(value, view, viewSize, vbuf);
@@ -139,7 +139,7 @@ class ItemInput : public MenuItem {
         char buf[maxCols];
         concat(text, ':', buf);
         concat(buf, vbuf, buf);
-        renderer->drawItem(itemIndex, screenRow, buf);
+        renderer->drawItem(screenRow, buf);
 
         delete[] vbuf;  // Free allocated memory
     }

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -85,12 +85,12 @@ class ItemList : public MenuItem {
     }
 
   protected:
-    void draw(MenuRenderer* renderer, uint8_t itemIndex, uint8_t screenRow) override {
+    void draw(MenuRenderer* renderer, uint8_t screenRow) override {
         uint8_t maxCols = renderer->getMaxCols();
         char buf[maxCols];
         concat(text, ':', buf);
         concat(buf, getValue(), buf);
-        renderer->drawItem(itemIndex, screenRow, buf);
+        renderer->drawItem(screenRow, buf);
     }
 
     bool process(LcdMenu* menu, const unsigned char command) override {

--- a/src/ItemRangeBase.h
+++ b/src/ItemRangeBase.h
@@ -107,12 +107,12 @@ class ItemRangeBase : public MenuItem {
     virtual char* getDisplayValue() = 0;
 
   protected:
-    void draw(MenuRenderer* renderer, uint8_t itemIndex, uint8_t screenRow) override {
+    void draw(MenuRenderer* renderer, uint8_t screenRow) override {
         uint8_t maxCols = renderer->getMaxCols();
         char buf[maxCols];
         concat(text, ':', buf);
         concat(buf, getDisplayValue(), buf);
-        renderer->drawItem(itemIndex, screenRow, buf);
+        renderer->drawItem(screenRow, buf);
     }
 
     bool process(LcdMenu* menu, const unsigned char command) override {

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -82,12 +82,12 @@ class ItemToggle : public MenuItem {
 
     const char* getTextOff() { return this->textOff; }
 
-    void draw(MenuRenderer* renderer, uint8_t itemIndex, uint8_t screenRow) override {
+    void draw(MenuRenderer* renderer, uint8_t screenRow) override {
         uint8_t maxCols = renderer->getMaxCols();
         char buf[maxCols];
         concat(text, ':', buf);
         concat(buf, enabled ? textOn : textOff, buf);
-        renderer->drawItem(itemIndex, screenRow, buf);
+        renderer->drawItem(screenRow, buf);
     };
 
   protected:

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -96,7 +96,6 @@ class MenuItem {
     /**
      * @brief Draw this menu item on specified display on specified row.
      * @param renderer The renderer to use for drawing.
-     * @param itemIndex The index of the item in the menu.
      * @param screenRow The row on the screen where the item should be drawn.
      */
     virtual void draw(MenuRenderer* renderer, uint8_t screenRow) {

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -91,7 +91,7 @@ class MenuItem {
      * @param renderer The renderer to use for drawing.
      */
     const void draw(MenuRenderer* renderer) {
-        draw(renderer, renderer->getItemIndex(), renderer->getActiveRow());
+        draw(renderer, renderer->getActiveRow());
     };
     /**
      * @brief Draw this menu item on specified display on specified row.
@@ -99,8 +99,8 @@ class MenuItem {
      * @param itemIndex The index of the item in the menu.
      * @param screenRow The row on the screen where the item should be drawn.
      */
-    virtual void draw(MenuRenderer* renderer, uint8_t itemIndex, uint8_t screenRow) {
-        renderer->drawItem(itemIndex, screenRow, text);
+    virtual void draw(MenuRenderer* renderer, uint8_t screenRow) {
+        renderer->drawItem(screenRow, text);
     };
 };
 

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -33,7 +33,6 @@ void MenuScreen::setCursor(MenuRenderer* renderer, uint8_t position) {
 
 void MenuScreen::draw(MenuRenderer* renderer) {
     renderer->restartTimer();
-    renderer->itemCount = itemCount;
     for (uint8_t i = 0; i < renderer->maxRows; i++) {
         MenuItem* item = this->items[view + i];
         if (item == nullptr) {

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -44,17 +44,9 @@ void MenuScreen::draw(MenuRenderer* renderer) {
     }
 }
 
-void MenuScreen::markScroll(uint8_t i, MenuRenderer* renderer) {
-    if (i == 0 && view > 0) {
-        renderer->flagHiddenItemsAbove();
-    } else {
-        renderer->unsetFlagHiddenItemsAbove();
-    }
-    if (i == renderer->maxRows - 1 && (view + renderer->maxRows) < itemCount) {
-        renderer->flagHiddenItemsBelow();
-    } else {
-        renderer->unsetFlagHiddenItemsBelow();
-    }
+void MenuScreen::markScroll(uint8_t index, MenuRenderer* renderer) {
+    renderer->hasHiddenItemsAbove = index == 0 && view > 0;
+    renderer->hasHiddenItemsBelow = index == renderer->maxRows - 1 && (view + renderer->maxRows) < itemCount;
 }
 
 bool MenuScreen::process(LcdMenu* menu, const unsigned char command) {

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -46,14 +46,14 @@ void MenuScreen::draw(MenuRenderer* renderer) {
 
 void MenuScreen::markScroll(uint8_t i, MenuRenderer* renderer) {
     if (i == 0 && view > 0) {
-        renderer->markUpScroll();
+        renderer->flagHiddenItemsAbove();
     } else {
-        renderer->clearUpScroll();
+        renderer->unsetFlagHiddenItemsAbove();
     }
     if (i == renderer->maxRows - 1 && (view + renderer->maxRows) < itemCount) {
-        renderer->markDownScroll();
+        renderer->flagHiddenItemsBelow();
     } else {
-        renderer->clearDownScroll();
+        renderer->unsetFlagHiddenItemsBelow();
     }
 }
 

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -39,19 +39,19 @@ void MenuScreen::draw(MenuRenderer* renderer) {
         if (item == nullptr) {
             break;
         }
-        markScroll(i, renderer);
+        updateScrollIndicators(i, renderer);
         item->draw(renderer, i);
     }
 }
 
-void MenuScreen::markScroll(uint8_t index, MenuRenderer* renderer) {
+void MenuScreen::updateScrollIndicators(uint8_t index, MenuRenderer* renderer) {
     renderer->hasHiddenItemsAbove = index == 0 && view > 0;
     renderer->hasHiddenItemsBelow = index == renderer->maxRows - 1 && (view + renderer->maxRows) < itemCount;
 }
 
 bool MenuScreen::process(LcdMenu* menu, const unsigned char command) {
     MenuRenderer* renderer = menu->getRenderer();
-    markScroll(cursor - view, renderer);
+    updateScrollIndicators(cursor - view, renderer);
     if (items[cursor]->process(menu, command)) {
         return true;
     }

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -39,13 +39,27 @@ void MenuScreen::draw(MenuRenderer* renderer) {
         if (item == nullptr) {
             break;
         }
-        item->draw(renderer, view + i, i);
+        markScroll(i, renderer);
+        item->draw(renderer, i);
+    }
+}
+
+void MenuScreen::markScroll(uint8_t i, MenuRenderer* renderer) {
+    if (i == 0 && view > 0) {
+        renderer->markUpScroll();
+    } else {
+        renderer->clearUpScroll();
+    }
+    if (i == renderer->maxRows - 1 && (view + renderer->maxRows) < itemCount) {
+        renderer->markDownScroll();
+    } else {
+        renderer->clearDownScroll();
     }
 }
 
 bool MenuScreen::process(LcdMenu* menu, const unsigned char command) {
     MenuRenderer* renderer = menu->getRenderer();
-    renderer->itemIndex = cursor;
+    markScroll(cursor - view, renderer);
     if (items[cursor]->process(menu, command)) {
         return true;
     }

--- a/src/MenuScreen.h
+++ b/src/MenuScreen.h
@@ -106,6 +106,10 @@ class MenuScreen {
      */
     void draw(MenuRenderer* renderer);
     /**
+     * @brief Mark scroll indicators.
+     */
+    void markScroll(uint8_t i, MenuRenderer* renderer);
+    /**
      * @brief Process the command.
      * @return `true` if the command was processed, `false` otherwise.
      */

--- a/src/MenuScreen.h
+++ b/src/MenuScreen.h
@@ -106,9 +106,9 @@ class MenuScreen {
      */
     void draw(MenuRenderer* renderer);
     /**
-     * @brief Mark scroll indicators.
+     * @brief Update scroll indicators.
      */
-    void markScroll(uint8_t i, MenuRenderer* renderer);
+    void updateScrollIndicators(uint8_t index, MenuRenderer* renderer);
     /**
      * @brief Process the command.
      * @return `true` if the command was processed, `false` otherwise.

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -63,8 +63,8 @@ void CharacterDisplayRenderer::appendCursorToText(uint8_t screenRow, const char*
 }
 
 void CharacterDisplayRenderer::appendIndicatorToText(uint8_t screenRow, const char* text, char* buf) {
-    uint8_t indicator = (hasHiddenItemsAbove) ? 1 : (hasHiddenItemsBelow) ? 2 : 0;
-    if (indicator != 0) {
+    uint8_t indicator = (hasHiddenItemsAbove) ? 1 : ((hasHiddenItemsBelow) ? 2 : 0);
+    if (indicator != 0 && upArrow != NULL && downArrow != NULL) {
         concat(text, indicator, buf);
     } else {
         strcpy(buf, text);

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -67,9 +67,9 @@ void CharacterDisplayRenderer::appendCursorToText(uint8_t screenRow, const char*
 
 void CharacterDisplayRenderer::appendIndicatorToText(uint8_t screenRow, const char* text, char* buf) {
     uint8_t indicator = 0;
-    if (upScroll) {
+    if (hasHiddenItemsAbove) {
         indicator = 1;
-    } else if (downScroll) {
+    } else if (hasHiddenItemsBelow) {
         indicator = 2;
     }
 
@@ -94,20 +94,4 @@ void CharacterDisplayRenderer::padText(const char* text, uint8_t itemIndex, char
 
 uint8_t CharacterDisplayRenderer::calculateAvailableLength() {
     return maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0);
-}
-
-void CharacterDisplayRenderer::markUpScroll() {
-    upScroll = true;
-}
-
-void CharacterDisplayRenderer::clearUpScroll() {
-    upScroll = false;
-}
-
-void CharacterDisplayRenderer::markDownScroll() {
-    downScroll = true;
-}
-
-void CharacterDisplayRenderer::clearDownScroll() {
-    downScroll = false;
 }

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -24,7 +24,7 @@ void CharacterDisplayRenderer::drawItem(uint8_t screenRow, const char* text) {
     buf[calculateAvailableLength()] = '\0';
     uint8_t cursorCol = strlen(buf);
 
-    padText(buf, maxCols, buf);
+    padText(buf, buf);
     appendIndicatorToText(screenRow, buf, buf);
 
     display->setCursor(0, screenRow);
@@ -83,7 +83,7 @@ void CharacterDisplayRenderer::appendIndicatorToText(uint8_t screenRow, const ch
     }
 }
 
-void CharacterDisplayRenderer::padText(const char* text, uint8_t itemIndex, char* buf) {
+void CharacterDisplayRenderer::padText(const char* text, char* buf) {
     uint8_t textLength = strlen(text);
     uint8_t spaces = (textLength > calculateAvailableLength()) ? 0 : calculateAvailableLength() - textLength;
     spaces = constrain(spaces, 0, maxCols);

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -50,19 +50,16 @@ void CharacterDisplayRenderer::moveCursor(uint8_t cursorCol, uint8_t cursorRow) 
 }
 
 void CharacterDisplayRenderer::appendCursorToText(uint8_t screenRow, const char* text, char* buf) {
-    uint8_t cursor;
-    if (activeRow == screenRow) {
-        cursor = inEditMode ? editCursorIcon : cursorIcon;
-    } else {
-        cursor = (cursorIcon != 0 || editCursorIcon != 0) ? ' ' : 0;
+    if (cursorIcon == 0 && editCursorIcon == 0) {
+        strncpy(buf, text, maxCols);
+        buf[maxCols] = '\0';
+        return;
     }
 
-    if (cursor != 0) {
-        buf[0] = cursor;
-        strcpy(buf + 1, text);
-    } else {
-        strcpy(buf, text);
-    }
+    uint8_t cursor = (activeRow == screenRow) ? (inEditMode ? editCursorIcon : cursorIcon) : ' ';
+    buf[0] = cursor;
+    strncpy(buf + 1, text, maxCols - 1);
+    buf[maxCols] = '\0';
 }
 
 void CharacterDisplayRenderer::appendIndicatorToText(uint8_t screenRow, const char* text, char* buf) {

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -16,8 +16,8 @@ void CharacterDisplayRenderer::begin() {
     static_cast<CharacterDisplayInterface*>(display)->createChar(2, downArrow);
 }
 
-void CharacterDisplayRenderer::drawItem(uint8_t itemIndex, uint8_t screenRow, const char* text) {
-    MenuRenderer::drawItem(itemIndex, screenRow, text);
+void CharacterDisplayRenderer::drawItem(uint8_t screenRow, const char* text) {
+    MenuRenderer::drawItem(screenRow, text);
     char buf[maxCols + 1];
 
     appendCursorToText(screenRow, text, buf);
@@ -25,7 +25,7 @@ void CharacterDisplayRenderer::drawItem(uint8_t itemIndex, uint8_t screenRow, co
     uint8_t cursorCol = strlen(buf);
 
     padText(buf, maxCols, buf);
-    appendIndicatorToText(itemIndex, screenRow, buf, buf);
+    appendIndicatorToText(screenRow, buf, buf);
 
     display->setCursor(0, screenRow);
     display->draw(buf);
@@ -65,11 +65,11 @@ void CharacterDisplayRenderer::appendCursorToText(uint8_t screenRow, const char*
     }
 }
 
-void CharacterDisplayRenderer::appendIndicatorToText(uint8_t itemIndex, uint8_t screenRow, const char* text, char* buf) {
+void CharacterDisplayRenderer::appendIndicatorToText(uint8_t screenRow, const char* text, char* buf) {
     uint8_t indicator = 0;
-    if (screenRow == 0 && itemIndex > 0) {
+    if (upScroll) {
         indicator = 1;
-    } else if (screenRow == maxRows - 1 && itemIndex < itemCount - 1) {
+    } else if (downScroll) {
         indicator = 2;
     }
 
@@ -94,4 +94,20 @@ void CharacterDisplayRenderer::padText(const char* text, uint8_t itemIndex, char
 
 uint8_t CharacterDisplayRenderer::calculateAvailableLength() {
     return maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0);
+}
+
+void CharacterDisplayRenderer::markUpScroll() {
+    upScroll = true;
+}
+
+void CharacterDisplayRenderer::clearUpScroll() {
+    upScroll = false;
+}
+
+void CharacterDisplayRenderer::markDownScroll() {
+    downScroll = true;
+}
+
+void CharacterDisplayRenderer::clearDownScroll() {
+    downScroll = false;
 }

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -63,13 +63,7 @@ void CharacterDisplayRenderer::appendCursorToText(uint8_t screenRow, const char*
 }
 
 void CharacterDisplayRenderer::appendIndicatorToText(uint8_t screenRow, const char* text, char* buf) {
-    uint8_t indicator = 0;
-    if (hasHiddenItemsAbove) {
-        indicator = 1;
-    } else if (hasHiddenItemsBelow) {
-        indicator = 2;
-    }
-
+    uint8_t indicator = (hasHiddenItemsAbove) ? 1 : (hasHiddenItemsBelow) ? 2 : 0;
     if (indicator != 0) {
         concat(text, indicator, buf);
     } else {

--- a/src/renderer/CharacterDisplayRenderer.h
+++ b/src/renderer/CharacterDisplayRenderer.h
@@ -52,11 +52,10 @@ class CharacterDisplayRenderer : public MenuRenderer {
      * text is longer than the available length, no padding is added.
      *
      * @param text The input text to be padded.
-     * @param itemIndex The index of the item (not used in the current implementation).
      * @param buf The buffer where the padded text will be stored. It should be large
      *            enough to hold the padded text.
      */
-    void padText(const char* text, uint8_t itemIndex, char* buf);
+    void padText(const char* text, char* buf);
 
     /**
      * @brief Calculates the available length for display.
@@ -107,7 +106,6 @@ class CharacterDisplayRenderer : public MenuRenderer {
      * truncating the text if it's too long, padding the text with spaces,
      * appending an indicator to the text, and finally drawing the text on the display.
      *
-     * @param itemIndex The index of the item in the menu.
      * @param screenRow The row on the screen where the item should be drawn.
      * @param text The text of the menu item to be drawn.
      */

--- a/src/renderer/CharacterDisplayRenderer.h
+++ b/src/renderer/CharacterDisplayRenderer.h
@@ -25,6 +25,8 @@ class CharacterDisplayRenderer : public MenuRenderer {
     uint8_t* downArrow;
     const uint8_t cursorIcon;
     const uint8_t editCursorIcon;
+    bool upScroll = false;
+    bool downScroll = false;
 
     /**
      * @brief Appends a cursor icon to the given text if the specified screen row is active.
@@ -38,12 +40,11 @@ class CharacterDisplayRenderer : public MenuRenderer {
     /**
      * @brief Appends an indicator to the provided text based on the item index and screen row.
      *
-     * @param itemIndex The index of the item in the list.
      * @param screenRow The row on the screen where the text will be displayed.
      * @param text The original text to which the indicator may be appended.
      * @param buf The buffer where the resulting text with the indicator will be stored.
      */
-    void appendIndicatorToText(uint8_t itemIndex, uint8_t screenRow, const char* text, char* buf);
+    void appendIndicatorToText(uint8_t screenRow, const char* text, char* buf);
 
     /**
      * @brief Pads the given text with spaces to fit within the available length.
@@ -112,9 +113,13 @@ class CharacterDisplayRenderer : public MenuRenderer {
      * @param screenRow The row on the screen where the item should be drawn.
      * @param text The text of the menu item to be drawn.
      */
-    void drawItem(uint8_t itemIndex, uint8_t screenRow, const char* text) override;
+    void drawItem(uint8_t screenRow, const char* text) override;
     void draw(uint8_t byte) override;
     void drawBlinker() override;
     void clearBlinker() override;
     void moveCursor(uint8_t cursorCol, uint8_t cursorRow) override;
+    void markUpScroll() override;
+    void clearUpScroll() override;
+    void markDownScroll() override;
+    void clearDownScroll() override;
 };

--- a/src/renderer/CharacterDisplayRenderer.h
+++ b/src/renderer/CharacterDisplayRenderer.h
@@ -25,8 +25,6 @@ class CharacterDisplayRenderer : public MenuRenderer {
     uint8_t* downArrow;
     const uint8_t cursorIcon;
     const uint8_t editCursorIcon;
-    bool upScroll = false;
-    bool downScroll = false;
 
     /**
      * @brief Appends a cursor icon to the given text if the specified screen row is active.
@@ -118,8 +116,4 @@ class CharacterDisplayRenderer : public MenuRenderer {
     void drawBlinker() override;
     void clearBlinker() override;
     void moveCursor(uint8_t cursorCol, uint8_t cursorRow) override;
-    void markUpScroll() override;
-    void clearUpScroll() override;
-    void markDownScroll() override;
-    void clearDownScroll() override;
 };

--- a/src/renderer/MenuRenderer.cpp
+++ b/src/renderer/MenuRenderer.cpp
@@ -40,3 +40,11 @@ uint8_t MenuRenderer::getMaxRows() const { return maxRows; }
 uint8_t MenuRenderer::getMaxCols() const { return maxCols; }
 
 uint8_t MenuRenderer::getActiveRow() const { return activeRow; }
+
+void MenuRenderer::flagHiddenItemsAbove() { hasHiddenItemsAbove = true; }
+
+void MenuRenderer::unsetFlagHiddenItemsAbove() { hasHiddenItemsAbove = false; }
+
+void MenuRenderer::flagHiddenItemsBelow() { hasHiddenItemsBelow = true; }
+
+void MenuRenderer::unsetFlagHiddenItemsBelow() { hasHiddenItemsBelow = false; }

--- a/src/renderer/MenuRenderer.cpp
+++ b/src/renderer/MenuRenderer.cpp
@@ -8,9 +8,8 @@ void MenuRenderer::begin() {
     startTime = millis();
 }
 
-void MenuRenderer::drawItem(uint8_t itemIndex, uint8_t screenRow, const char* text) {
+void MenuRenderer::drawItem(uint8_t screenRow, const char* text) {
     this->cursorRow = screenRow;
-    this->itemIndex = itemIndex;
 }
 
 void MenuRenderer::moveCursor(uint8_t cursorCol, uint8_t cursorRow) {
@@ -39,7 +38,5 @@ uint8_t MenuRenderer::getCursorRow() const { return cursorRow; }
 uint8_t MenuRenderer::getMaxRows() const { return maxRows; }
 
 uint8_t MenuRenderer::getMaxCols() const { return maxCols; }
-
-uint8_t MenuRenderer::getItemIndex() const { return itemIndex; }
 
 uint8_t MenuRenderer::getActiveRow() const { return activeRow; }

--- a/src/renderer/MenuRenderer.cpp
+++ b/src/renderer/MenuRenderer.cpp
@@ -40,11 +40,3 @@ uint8_t MenuRenderer::getMaxRows() const { return maxRows; }
 uint8_t MenuRenderer::getMaxCols() const { return maxCols; }
 
 uint8_t MenuRenderer::getActiveRow() const { return activeRow; }
-
-void MenuRenderer::flagHiddenItemsAbove() { hasHiddenItemsAbove = true; }
-
-void MenuRenderer::unsetFlagHiddenItemsAbove() { hasHiddenItemsAbove = false; }
-
-void MenuRenderer::flagHiddenItemsBelow() { hasHiddenItemsBelow = true; }
-
-void MenuRenderer::unsetFlagHiddenItemsBelow() { hasHiddenItemsBelow = false; }

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -149,26 +149,6 @@ class MenuRenderer {
      * @return the active row.
      */
     uint8_t getActiveRow() const;
-
-    /**
-     * @brief Flags that there are hidden items above the current view.
-     */
-    void flagHiddenItemsAbove();
-
-    /**
-     * @brief Unsets the flag indicating hidden items above the current view.
-     */
-    void unsetFlagHiddenItemsAbove();
-
-    /**
-     * @brief Flags that there are hidden items below the current view.
-     */
-    void flagHiddenItemsBelow();
-
-    /**
-     * @brief Unsets the flag indicating hidden items below the current view.
-     */
-    void unsetFlagHiddenItemsBelow();
 };
 
 #endif  // MENU_RENDERER_H

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -27,7 +27,6 @@ class MenuRenderer {
 
     uint8_t blinkerPosition;
 
-    uint8_t itemIndex;
     uint8_t itemCount;
 
     bool inEditMode;
@@ -65,7 +64,12 @@ class MenuRenderer {
      * @param screenRow Row on the screen where the item should be drawn.
      * @param text Text of the item to be drawn.
      */
-    virtual void drawItem(uint8_t itemIndex, uint8_t screenRow, const char* text);
+    virtual void drawItem(uint8_t screenRow, const char* text);
+
+    virtual void markUpScroll() = 0;
+    virtual void clearUpScroll() = 0;
+    virtual void markDownScroll() = 0;
+    virtual void clearDownScroll() = 0;
 
     /**
      * @brief Function to clear the blinker from the display.
@@ -135,12 +139,6 @@ class MenuRenderer {
      * @return Maximum number of columns.
      */
     uint8_t getMaxCols() const;
-
-    /**
-     * @brief Gets the index of the current item.
-     * @return Index of the current item.
-     */
-    uint8_t getItemIndex() const;
 
     /**
      * @brief Get the active row.

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -20,6 +20,15 @@ class MenuRenderer {
     const uint8_t maxCols;
     const uint8_t maxRows;
 
+    /**
+     * @brief Flag indicating that there are hidden items above the current view.
+     */
+    bool hasHiddenItemsAbove = false;
+    /**
+     * @brief Flag indicating that there are hidden items below the current view.
+     */
+    bool hasHiddenItemsBelow = false;
+
     uint8_t cursorCol;
     uint8_t cursorRow;
 
@@ -65,11 +74,6 @@ class MenuRenderer {
      * @param text Text of the item to be drawn.
      */
     virtual void drawItem(uint8_t screenRow, const char* text);
-
-    virtual void markUpScroll() = 0;
-    virtual void clearUpScroll() = 0;
-    virtual void markDownScroll() = 0;
-    virtual void clearDownScroll() = 0;
 
     /**
      * @brief Function to clear the blinker from the display.
@@ -145,6 +149,26 @@ class MenuRenderer {
      * @return the active row.
      */
     uint8_t getActiveRow() const;
+
+    /**
+     * @brief Flags that there are hidden items above the current view.
+     */
+    void flagHiddenItemsAbove();
+
+    /**
+     * @brief Unsets the flag indicating hidden items above the current view.
+     */
+    void unsetFlagHiddenItemsAbove();
+
+    /**
+     * @brief Flags that there are hidden items below the current view.
+     */
+    void flagHiddenItemsBelow();
+
+    /**
+     * @brief Unsets the flag indicating hidden items below the current view.
+     */
+    void unsetFlagHiddenItemsBelow();
 };
 
 #endif  // MENU_RENDERER_H

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -36,8 +36,6 @@ class MenuRenderer {
 
     uint8_t blinkerPosition;
 
-    uint8_t itemCount;
-
     bool inEditMode;
 
     unsigned long startTime = 0;


### PR DESCRIPTION
## Description

Remove `itemIndex` dependency from renderer as it is internal information of MenuScreen
Reported by @ShishkinDmitriy

---

### Checklist

<!-- Note: Without all of these items checked the PR will not be reviewed. -->

#### General Requirements

- [x] I have kept this PR in draft until all the required tasks are completed.
- [x] I have reviewed the [contributing guidelines](/CONTRIBUTING.md) for this project.
- [x] I have checked that this PR does not introduce any breaking changes unless explicitly stated.
- [x] I have checked that changes generate no new warnings.
- [x] I have performed a self-review of my own code

#### Feature/Enhancement

<!-- Delete this section if it doesn't apply to your PR. -->

- [x] **This PR is a new feature/enhancement**
- [x] I have tagged this PR with `enhancement`.
- [x] I have included an example sketch file.
- [x] I have commented my code thoroughly.
- [x] I have added documentation for the new feature.
- [x] I have [generated](/docs/README.md) and reviewed the documentation locally.
- [x] I have created a [functionality test](/test/README.md) to validate the new feature.
