### PR TITLE
Patch/remove screen row dependency in renderer

### DIFF
--- a/docs/source/overview/rendering/character-display.rst
+++ b/docs/source/overview/rendering/character-display.rst
@@ -171,7 +171,7 @@ Here is basic example of how to create a custom renderer:
             : CharacterDisplayRenderer(display, cols, rows) {
         }
 
-        void drawItem(uint8_t screenRow, const char* text) override {
+        void drawItem(const char* text) override {
             // Custom rendering code here
             // The text parameter contains the menu item text and the value of the item if present
             // eg. "Item 1" or "Item 1:42"

--- a/docs/source/overview/rendering/character-display.rst
+++ b/docs/source/overview/rendering/character-display.rst
@@ -171,7 +171,7 @@ Here is basic example of how to create a custom renderer:
             : CharacterDisplayRenderer(display, cols, rows) {
         }
 
-        void drawItem(uint8_t itemIndex, uint8_t screenRow, const char* text) override {
+        void drawItem(uint8_t screenRow, const char* text) override {
             // Custom rendering code here
             // The text parameter contains the menu item text and the value of the item if present
             // eg. "Item 1" or "Item 1:42"

--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -129,7 +129,7 @@ class ItemInput : public MenuItem {
     fptrStr getCallbackStr() { return callback; }
 
   protected:
-    void draw(MenuRenderer* renderer, uint8_t screenRow) override {
+    void draw(MenuRenderer* renderer) override {
         uint8_t viewSize = getViewSize(renderer);
         char* vbuf = new char[viewSize + 1];
         substring(value, view, viewSize, vbuf);
@@ -139,7 +139,7 @@ class ItemInput : public MenuItem {
         char buf[maxCols];
         concat(text, ':', buf);
         concat(buf, vbuf, buf);
-        renderer->drawItem(screenRow, buf);
+        renderer->drawItem(buf);
 
         delete[] vbuf;  // Free allocated memory
     }
@@ -197,11 +197,10 @@ class ItemInput : public MenuItem {
         }
         // Redraw
         renderer->setEditMode(true);
-        MenuItem::draw(renderer);
-        renderer->moveCursor(renderer->getCursorCol(), renderer->getActiveRow());
+        draw(renderer);
         renderer->drawBlinker();
         // Log
-        printLog(F("ItemInput::enterEditMode"), value);
+        printLog(F("ItemInput::enterEditMode"), cursor);
     };
     void back(MenuRenderer* renderer) {
         renderer->clearBlinker();
@@ -209,12 +208,12 @@ class ItemInput : public MenuItem {
         // Move view to 0 and redraw before exit
         cursor = 0;
         view = 0;
-        MenuItem::draw(renderer);
+        draw(renderer);
         if (callback != NULL) {
             callback(value);
         }
         // Log
-        printLog(F("ItemInput::exitEditMode"), value);
+        printLog(F("ItemInput::exitEditMode"), cursor);
     };
     void left(MenuRenderer* renderer) {
         if (cursor == 0) {
@@ -223,7 +222,7 @@ class ItemInput : public MenuItem {
         cursor--;
         if (cursor < view) {
             view--;
-            MenuItem::draw(renderer);
+            draw(renderer);
         }
         renderer->moveCursor(renderer->getCursorCol() - 1, renderer->getCursorRow());
         renderer->drawBlinker();
@@ -241,7 +240,7 @@ class ItemInput : public MenuItem {
         uint8_t viewSize = getViewSize(renderer);
         if (cursor > (view + viewSize - 1)) {
             view++;
-            MenuItem::draw(renderer);
+            draw(renderer);
         }
         renderer->moveCursor(renderer->getCursorCol() + 1, renderer->getCursorRow());
         renderer->drawBlinker();
@@ -261,7 +260,7 @@ class ItemInput : public MenuItem {
             view--;
         }
         uint8_t cursorCol = renderer->getCursorCol();
-        MenuItem::draw(renderer);
+        draw(renderer);
         renderer->moveCursor(cursorCol - 1, renderer->getCursorRow());
         renderer->drawBlinker();
         // Log
@@ -299,7 +298,7 @@ class ItemInput : public MenuItem {
         if (cursor > (view + viewSize - 1)) {
             view++;
         }
-        MenuItem::draw(renderer);
+        draw(renderer);
         renderer->drawBlinker();
         // Log
         printLog(F("ItemInput::typeChar"), character);
@@ -309,7 +308,7 @@ class ItemInput : public MenuItem {
      */
     void clear(MenuRenderer* renderer) {
         value = (char*)"";
-        MenuItem::draw(renderer);
+        draw(renderer);
         renderer->drawBlinker();
         // Log
         printLog(F("ItemInput::clear"), value);

--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -200,7 +200,7 @@ class ItemInput : public MenuItem {
         draw(renderer);
         renderer->drawBlinker();
         // Log
-        printLog(F("ItemInput::enterEditMode"), cursor);
+        printLog(F("ItemInput::enterEditMode"), value);
     };
     void back(MenuRenderer* renderer) {
         renderer->clearBlinker();
@@ -213,7 +213,7 @@ class ItemInput : public MenuItem {
             callback(value);
         }
         // Log
-        printLog(F("ItemInput::exitEditMode"), cursor);
+        printLog(F("ItemInput::exitEditMode"), value);
     };
     void left(MenuRenderer* renderer) {
         if (cursor == 0) {

--- a/src/ItemInputCharset.h
+++ b/src/ItemInputCharset.h
@@ -166,9 +166,9 @@ class ItemInputCharset : public ItemInput {
     }
 
     void drawChar(MenuRenderer* renderer) {
-        renderer->moveCursor(renderer->getCursorCol(), renderer->getActiveRow());
+        renderer->moveCursor(renderer->getCursorCol(), renderer->getCursorRow());
         renderer->draw(charset[charsetPosition]);
-        renderer->moveCursor(renderer->getCursorCol(), renderer->getActiveRow());
+        renderer->moveCursor(renderer->getCursorCol(), renderer->getCursorRow());
     }
 };
 

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -85,12 +85,12 @@ class ItemList : public MenuItem {
     }
 
   protected:
-    void draw(MenuRenderer* renderer, uint8_t screenRow) override {
+    void draw(MenuRenderer* renderer) override {
         uint8_t maxCols = renderer->getMaxCols();
         char buf[maxCols];
         concat(text, ':', buf);
         concat(buf, getValue(), buf);
-        renderer->drawItem(screenRow, buf);
+        renderer->drawItem(buf);
     }
 
     bool process(LcdMenu* menu, const unsigned char command) override {
@@ -99,7 +99,7 @@ class ItemList : public MenuItem {
             switch (command) {
                 case BACK:
                     renderer->setEditMode(false);
-                    MenuItem::draw(renderer);
+                    draw(renderer);
                     if (callback != NULL) {
                         callback(itemIndex);
                     }
@@ -118,7 +118,7 @@ class ItemList : public MenuItem {
             switch (command) {
                 case ENTER:
                     renderer->setEditMode(true);
-                    MenuItem::draw(renderer);
+                    draw(renderer);
                     printLog(F("ItemList::enterEditMode"), getValue());
                     return true;
                 default:
@@ -131,7 +131,7 @@ class ItemList : public MenuItem {
         uint8_t previousIndex = itemIndex;
         (int8_t)(itemIndex - 1) < 0 ? itemIndex = itemCount - 1 : itemIndex--;
         if (previousIndex != itemIndex) {
-            MenuItem::draw(renderer);
+            draw(renderer);
         }
         printLog(F("ItemList::selectPrevious"), getValue());
     };
@@ -140,7 +140,7 @@ class ItemList : public MenuItem {
         uint8_t previousIndex = itemIndex;
         itemIndex = constrain((itemIndex + 1) % itemCount, 0, itemCount - 1);
         if (previousIndex != itemIndex) {
-            MenuItem::draw(renderer);
+            draw(renderer);
         }
         printLog(F("ItemList::selectNext"), getValue());
     };

--- a/src/ItemRangeBase.h
+++ b/src/ItemRangeBase.h
@@ -107,12 +107,12 @@ class ItemRangeBase : public MenuItem {
     virtual char* getDisplayValue() = 0;
 
   protected:
-    void draw(MenuRenderer* renderer, uint8_t screenRow) override {
+    void draw(MenuRenderer* renderer) override {
         uint8_t maxCols = renderer->getMaxCols();
         char buf[maxCols];
         concat(text, ':', buf);
         concat(buf, getDisplayValue(), buf);
-        renderer->drawItem(screenRow, buf);
+        renderer->drawItem(buf);
     }
 
     bool process(LcdMenu* menu, const unsigned char command) override {
@@ -121,7 +121,7 @@ class ItemRangeBase : public MenuItem {
             switch (command) {
                 case BACK:
                     renderer->setEditMode(false);
-                    MenuItem::draw(renderer);
+                    draw(renderer);
                     if (callback != NULL && !commitOnChange) {
                         callback(currentValue);
                     }
@@ -129,7 +129,7 @@ class ItemRangeBase : public MenuItem {
                     return true;
                 case UP:
                     if (increment()) {
-                        MenuItem::draw(renderer);
+                        draw(renderer);
                         if (commitOnChange && callback != NULL) {
                             callback(currentValue);
                         }
@@ -137,7 +137,7 @@ class ItemRangeBase : public MenuItem {
                     return true;
                 case DOWN:
                     if (decrement()) {
-                        MenuItem::draw(renderer);
+                        draw(renderer);
                         if (commitOnChange && callback != NULL) {
                             callback(currentValue);
                         }
@@ -150,7 +150,7 @@ class ItemRangeBase : public MenuItem {
             switch (command) {
                 case ENTER:
                     renderer->setEditMode(true);
-                    MenuItem::draw(renderer);
+                    draw(renderer);
                     printLog(F("ItemRangeBase::enterEditMode"), currentValue);
                     return true;
                 default:

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -82,12 +82,12 @@ class ItemToggle : public MenuItem {
 
     const char* getTextOff() { return this->textOff; }
 
-    void draw(MenuRenderer* renderer, uint8_t screenRow) override {
+    void draw(MenuRenderer* renderer) override {
         uint8_t maxCols = renderer->getMaxCols();
         char buf[maxCols];
         concat(text, ':', buf);
         concat(buf, enabled ? textOn : textOff, buf);
-        renderer->drawItem(screenRow, buf);
+        renderer->drawItem(buf);
     };
 
   protected:
@@ -101,13 +101,13 @@ class ItemToggle : public MenuItem {
                 return false;
         }
     };
-    void toggle(MenuRenderer* display) {
+    void toggle(MenuRenderer* renderer) {
         enabled = !enabled;
         if (callback != NULL) {
             callback(enabled);
         }
         printLog(F("ItemToggle::toggle"), enabled ? textOn : textOff);
-        MenuItem::draw(display);
+        draw(renderer);
     }
 };
 

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -90,16 +90,8 @@ class MenuItem {
      * @brief Draw this menu item on specified display on current row.
      * @param renderer The renderer to use for drawing.
      */
-    const void draw(MenuRenderer* renderer) {
-        draw(renderer, renderer->getActiveRow());
-    };
-    /**
-     * @brief Draw this menu item on specified display on specified row.
-     * @param renderer The renderer to use for drawing.
-     * @param screenRow The row on the screen where the item should be drawn.
-     */
-    virtual void draw(MenuRenderer* renderer, uint8_t screenRow) {
-        renderer->drawItem(screenRow, text);
+    virtual void draw(MenuRenderer* renderer) {
+        renderer->drawItem(text);
     };
 };
 

--- a/src/MenuScreen.h
+++ b/src/MenuScreen.h
@@ -69,8 +69,6 @@ class MenuScreen {
 
     uint8_t itemCount = 0;
 
-    void renderCursor(MenuRenderer* renderer);
-
   public:
     /**
      * Constructor
@@ -106,9 +104,9 @@ class MenuScreen {
      */
     void draw(MenuRenderer* renderer);
     /**
-     * @brief Update scroll indicators.
+     * @brief Sync indicators with the renderer.
      */
-    void updateScrollIndicators(uint8_t index, MenuRenderer* renderer);
+    void syncIndicators(uint8_t index, MenuRenderer* renderer);
     /**
      * @brief Process the command.
      * @return `true` if the command was processed, `false` otherwise.

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -16,20 +16,19 @@ void CharacterDisplayRenderer::begin() {
     static_cast<CharacterDisplayInterface*>(display)->createChar(2, downArrow);
 }
 
-void CharacterDisplayRenderer::drawItem(uint8_t screenRow, const char* text) {
-    MenuRenderer::drawItem(screenRow, text);
+void CharacterDisplayRenderer::drawItem(const char* text) {
     char buf[maxCols + 1];
 
-    appendCursorToText(screenRow, text, buf);
+    appendCursorToText(text, buf);
     buf[calculateAvailableLength()] = '\0';
     uint8_t cursorCol = strlen(buf);
 
     padText(buf, buf);
-    appendIndicatorToText(screenRow, buf, buf);
+    appendIndicatorToText(buf, buf);
 
-    display->setCursor(0, screenRow);
+    display->setCursor(0, cursorRow);
     display->draw(buf);
-    moveCursor(cursorCol, screenRow);
+    moveCursor(cursorCol, cursorRow);
 }
 
 void CharacterDisplayRenderer::draw(uint8_t byte) {
@@ -49,20 +48,20 @@ void CharacterDisplayRenderer::moveCursor(uint8_t cursorCol, uint8_t cursorRow) 
     display->setCursor(cursorCol, cursorRow);
 }
 
-void CharacterDisplayRenderer::appendCursorToText(uint8_t screenRow, const char* text, char* buf) {
+void CharacterDisplayRenderer::appendCursorToText(const char* text, char* buf) {
     if (cursorIcon == 0 && editCursorIcon == 0) {
         strncpy(buf, text, maxCols);
         buf[maxCols] = '\0';
         return;
     }
 
-    uint8_t cursor = (activeRow == screenRow) ? (inEditMode ? editCursorIcon : cursorIcon) : ' ';
+    uint8_t cursor = hasFocus ? (inEditMode ? editCursorIcon : cursorIcon) : ' ';
     buf[0] = cursor;
     strncpy(buf + 1, text, maxCols - 1);
     buf[maxCols] = '\0';
 }
 
-void CharacterDisplayRenderer::appendIndicatorToText(uint8_t screenRow, const char* text, char* buf) {
+void CharacterDisplayRenderer::appendIndicatorToText(const char* text, char* buf) {
     uint8_t indicator = (hasHiddenItemsAbove) ? 1 : ((hasHiddenItemsBelow) ? 2 : 0);
     if (indicator != 0 && upArrow != NULL && downArrow != NULL) {
         concat(text, indicator, buf);

--- a/src/renderer/CharacterDisplayRenderer.h
+++ b/src/renderer/CharacterDisplayRenderer.h
@@ -29,20 +29,18 @@ class CharacterDisplayRenderer : public MenuRenderer {
     /**
      * @brief Appends a cursor icon to the given text if the specified screen row is active.
      *
-     * @param screenRow The row on the screen to check against the active row.
      * @param text The original text to which the cursor icon will be appended.
      * @param buf The buffer where the resulting text with the cursor icon will be stored.
      */
-    void appendCursorToText(uint8_t screenRow, const char* text, char* buf);
+    void appendCursorToText(const char* text, char* buf);
 
     /**
      * @brief Appends an indicator to the provided text based on the item index and screen row.
      *
-     * @param screenRow The row on the screen where the text will be displayed.
      * @param text The original text to which the indicator may be appended.
      * @param buf The buffer where the resulting text with the indicator will be stored.
      */
-    void appendIndicatorToText(uint8_t screenRow, const char* text, char* buf);
+    void appendIndicatorToText(const char* text, char* buf);
 
     /**
      * @brief Pads the given text with spaces to fit within the available length.
@@ -106,10 +104,9 @@ class CharacterDisplayRenderer : public MenuRenderer {
      * truncating the text if it's too long, padding the text with spaces,
      * appending an indicator to the text, and finally drawing the text on the display.
      *
-     * @param screenRow The row on the screen where the item should be drawn.
      * @param text The text of the menu item to be drawn.
      */
-    void drawItem(uint8_t screenRow, const char* text) override;
+    void drawItem(const char* text) override;
     void draw(uint8_t byte) override;
     void drawBlinker() override;
     void clearBlinker() override;

--- a/src/renderer/MenuRenderer.cpp
+++ b/src/renderer/MenuRenderer.cpp
@@ -8,10 +8,6 @@ void MenuRenderer::begin() {
     startTime = millis();
 }
 
-void MenuRenderer::drawItem(uint8_t screenRow, const char* text) {
-    this->cursorRow = screenRow;
-}
-
 void MenuRenderer::moveCursor(uint8_t cursorCol, uint8_t cursorRow) {
     this->cursorCol = cursorCol;
     this->cursorRow = cursorRow;
@@ -38,5 +34,3 @@ uint8_t MenuRenderer::getCursorRow() const { return cursorRow; }
 uint8_t MenuRenderer::getMaxRows() const { return maxRows; }
 
 uint8_t MenuRenderer::getMaxCols() const { return maxCols; }
-
-uint8_t MenuRenderer::getActiveRow() const { return activeRow; }

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -29,10 +29,13 @@ class MenuRenderer {
      */
     bool hasHiddenItemsBelow = false;
 
+    /**
+     * @brief Flag indicating that the current item has focus.
+     */
+    bool hasFocus = false;
+
     uint8_t cursorCol;
     uint8_t cursorRow;
-
-    uint8_t activeRow;
 
     uint8_t blinkerPosition;
 
@@ -67,11 +70,9 @@ class MenuRenderer {
 
     /**
      * @brief Draws an item on the display.
-     * @param itemIndex Index of the item to be drawn.
-     * @param screenRow Row on the screen where the item should be drawn.
      * @param text Text of the item to be drawn.
      */
-    virtual void drawItem(uint8_t screenRow, const char* text);
+    virtual void drawItem(const char* text) = 0;
 
     /**
      * @brief Function to clear the blinker from the display.
@@ -141,12 +142,6 @@ class MenuRenderer {
      * @return Maximum number of columns.
      */
     uint8_t getMaxCols() const;
-
-    /**
-     * @brief Get the active row.
-     * @return the active row.
-     */
-    uint8_t getActiveRow() const;
 };
 
 #endif  // MENU_RENDERER_H


### PR DESCRIPTION
## Description

- Updated draw methods in multiple classes to remove the `activeRow` parameter and utilize the renderer directly for drawing. Items don't need to know what the activeRow is, they only need to request for their data to be drawn and the renderer handles drawing them on the right place.
- Synced indicators and cursor position accordingly.

## Screenshots/Video (if applicable)

https://github.com/user-attachments/assets/4dfb5a15-be63-49d0-b7e0-f5b99bf2df64

---

### Checklist

#### General Requirements

- [x] I have kept this PR in draft until all the required tasks are completed.
- [x] I have reviewed the [contributing guidelines](/CONTRIBUTING.md) for this project.
- [x] I have checked that this PR does not introduce any breaking changes unless explicitly stated.
- [x] I have checked that changes generate no new warnings.
- [x] I have performed a self-review of my own code

#### Feature/Enhancement

- [x] **This PR is a new feature/enhancement**
- [x] I have tagged this PR with `enhancement`.
- [x] I have included an example sketch file.
- [x] I have commented my code thoroughly.
- [x] I have added documentation for the new feature.
- [x] I have [generated](/docs/README.md) and reviewed the documentation locally.
- [x] I have created a [functionality test](/test/README.md) to validate the new feature.
