### PR TITLE
Update API references to use C++ syntax for better clarity and consistency

### DIFF
--- a/docs/source/overview/control/button.rst
+++ b/docs/source/overview/control/button.rst
@@ -55,4 +55,4 @@ Finally, you need to observe the ButtonAdapter object in the loop function:
 
 The ButtonAdapter will take care of translating the physical button presses into menu controls, allowing you to navigate through the menu system with ease.
 
-For more information about the ButtonAdapter, check the :doc:`API reference </reference/api/input/ButtonAdapter>`.
+For more information about the ButtonAdapter, check the :cpp:class:`API reference <ButtonAdapter>`.

--- a/docs/source/overview/control/index.rst
+++ b/docs/source/overview/control/index.rst
@@ -18,7 +18,7 @@ Here are some of the built-in controls that you can use to navigate through the 
 The other controls are used in specific scenarios, such as when you need to adjust a value in an input item or delete characters in an input field.
 The back control can be bound to a menu item, allowing you to navigate back to the previous menu screen without having to use a dedicated "Back" button.
 
-You can perform an action on the menu by calling the ``process(cmd)`` method on the menu object, where ``cmd`` is the control command you want to execute.
+You can perform an action on the menu by calling the :cpp:func:`LcdMenu::process` method on the menu object and pass the command you want to execute.
 For example, to move the selection down in the menu, you can call ``menu.process(DOWN)``.
 
 Luckily, you don't have to worry about implementing these controls yourself.

--- a/docs/source/overview/control/keyboard.rst
+++ b/docs/source/overview/control/keyboard.rst
@@ -44,4 +44,4 @@ Finally, you need to observe the KeyboardAdapter object in the loop function:
 
 The ``KeyboardAdapter`` will take care of translating the keyboard inputs into menu controls, allowing you to navigate through the menu system with ease.
 
-For more information about the ``KeyboardAdapter``, check the :doc:`API reference </reference/api/input/KeyboardAdapter>`.
+For more information about the ``KeyboardAdapter``, check the :cpp:class:`API reference <KeyboardAdapter>`.

--- a/docs/source/overview/control/rotary-encoder.rst
+++ b/docs/source/overview/control/rotary-encoder.rst
@@ -46,4 +46,4 @@ Finally, you need to observe the SimpleRotaryAdapter object in the loop function
 
 The ``SimpleRotaryAdapter`` will take care of translating the rotary encoder movements into menu controls, allowing you to navigate through the menu system with ease.
 
-For more information about the ``SimpleRotaryAdapter``, check the :doc:`API reference </reference/api/input/SimpleRotaryAdapter>`.
+For more information about the ``SimpleRotaryAdapter``, check the :cpp:class:`API reference <SimpleRotaryAdapter>`.

--- a/docs/source/overview/items/basic.rst
+++ b/docs/source/overview/items/basic.rst
@@ -19,4 +19,4 @@ This is how a basic menu item is rendered on a 16x2 LCD screen:
     :width: 400px
     :alt: Basic menu item
 
-Find more information about the basic menu item in the :doc:`API reference </reference/api/MenuItem>`.
+Find more information about the basic menu item in the :cpp:class:`API reference <MenuItem>`.

--- a/docs/source/overview/items/command.rst
+++ b/docs/source/overview/items/command.rst
@@ -67,7 +67,7 @@ This is useful when you don't have a dedicated "Back" input button on your setup
 
 When the "Back" menu item is selected, the menu will navigate back to the previous screen.
 
-Find more information about the command menu item :doc:`here </reference/api/ItemCommand>` and the back menu item :doc:`here </reference/api/ItemBack>`.
+Find more information about the command menu item :cpp:class:`here <ItemCommand>` and the back menu item :cpp:class:`here <ItemBack>`.
 
 Toggle menu item
 ~~~~~~~~~~~~~~~~
@@ -84,7 +84,7 @@ A toggle command menu item can be created using the following syntax:
     })
 
 The toggle command menu item takes a lambda function that accepts a boolean parameter representing the current state of the item.
-There are other ways to create a toggle command menu item, check the :doc:`API reference </reference/api/ItemToggle>` for more information.
+There are other ways to create a toggle command menu item, check the :cpp:class:`API reference <ItemToggle>` for more information.
 
 Example
 +++++++

--- a/docs/source/overview/items/input-charset.rst
+++ b/docs/source/overview/items/input-charset.rst
@@ -35,4 +35,4 @@ The input value will be restricted to the characters specified in the charset.
 
 You can create multiple charset input items in the same menu screen, each with its own label, default value, and charset.
 
-For more information about the charset input item, check the :doc:`API reference </reference/api/ItemInputCharset>`.
+For more information about the charset input item, check the :cpp:class:`API reference <ItemInputCharset>`.

--- a/docs/source/overview/items/input.rst
+++ b/docs/source/overview/items/input.rst
@@ -51,4 +51,4 @@ This item can be further extended by creating a new class which inherits from ``
         }
     };
 
-For more information about the input item, check the :doc:`API reference </reference/api/ItemInput>`.
+For more information about the input item, check the :cpp:class:`API reference <ItemInput>`.

--- a/docs/source/overview/items/list.rst
+++ b/docs/source/overview/items/list.rst
@@ -41,4 +41,4 @@ When the ``List 1`` menu item is selected, the list of items will be displayed o
 
 You can create multiple list menu items in the same menu screen, each with its own list of items.
 
-Find more information about the list menu item in the :doc:`API reference </reference/api/ItemList>`.
+Find more information about the list menu item in the :cpp:class:`API reference <ItemList>`.

--- a/docs/source/overview/items/range.rst
+++ b/docs/source/overview/items/range.rst
@@ -85,4 +85,4 @@ When the ``Dist`` menu item is selected, the user can adjust the pressure within
     The default behavior is to commit the value only when the user exits the item.
     Check the API reference for more information on how to configure this behavior.
 
-Find more information about the range menu item in the :doc:`API reference </reference/api/ItemFloatRange>`.
+Find more information about the range menu item in the :cpp:class:`API reference <ItemFloatRange>`.

--- a/docs/source/overview/items/submenu.rst
+++ b/docs/source/overview/items/submenu.rst
@@ -34,4 +34,4 @@ When the ``Sub-menu 1`` menu item is selected, the sub-menu screen will be displ
 
 You can create multiple levels of sub-menus by nesting sub-menu items within other sub-menu screens.
 
-Find more information about the sub-menu item in the :doc:`API reference </reference/api/ItemSubMenu>`.
+Find more information about the sub-menu item in the :cpp:class:`API reference <ItemSubMenu>`.

--- a/docs/source/overview/rendering/character-display.rst
+++ b/docs/source/overview/rendering/character-display.rst
@@ -18,8 +18,8 @@ The renderer is easy to use and provides a number of options for customizing the
 How to use the character display renderer
 -----------------------------------------
 
-To use the character display renderer, you need to create an instance of the ``CharacterDisplayRenderer`` class and pass it
-to the ``LcdMenu`` class when you create it. Here is an example:
+To use the character display renderer, you need to create an instance of the :cpp:class:`CharacterDisplayRenderer` class and pass it
+to the :cpp:class:`LcdMenu` class when you create it. Here is an example:
 
 .. tab-set::
     :sync-group: display
@@ -180,6 +180,4 @@ Here is basic example of how to create a custom renderer:
         }
     };
 
-    MyCustomRenderer renderer(&lcdAdapter, LCD_COLS, LCD_ROWS);
-
-Find more information about the character display renderer in the :doc:`API reference </reference/api/renderer/CharacterDisplayRenderer>`.
+Find more information about the character display renderer in the :cpp:class:`API reference <CharacterDisplayRenderer>`.

--- a/docs/source/overview/rendering/index.rst
+++ b/docs/source/overview/rendering/index.rst
@@ -7,6 +7,10 @@ The renderers are responsible for drawing the menu items on the screen. They can
 There are lots of opportunities to create your own custom renderer. You can create a renderer for any output device that you like.
 For example, you could create a renderer for a TFT display, a touchscreen, or even a 3D printer 😄 (the frame rate would be atrocious)
 
+.. hint::
+
+    Renderers can be helpful when you want to customize the appearance of the menu items, such as changing the font size, color, or layout.
+
 .. toctree::
     :maxdepth: 2
     :caption: The library comes with the following built-in renderers:


### PR DESCRIPTION
- Updated references to API classes in various documentation files to use C++ syntax for clarity and consistency.
- Replaced references using `:doc:` with `:cpp:class:` for API classes in the documentation.