### PR TITLE
Delegate Rendering of Separator and Value to Renderer

### DIFF
--- a/docs/source/overview/rendering/character-display.rst
+++ b/docs/source/overview/rendering/character-display.rst
@@ -171,10 +171,8 @@ Here is basic example of how to create a custom renderer:
             : CharacterDisplayRenderer(display, cols, rows) {
         }
 
-        void drawItem(const char* text) override {
+        void drawItem(const char* text, const char * value) override {
             // Custom rendering code here
-            // The text parameter contains the menu item text and the value of the item if present
-            // eg. "Item 1" or "Item 1:42"
             // 
             // You can append a cursor character to the text if the item is selected etc.
         }

--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -131,10 +131,11 @@ class ItemInput : public MenuItem {
   protected:
     void draw(MenuRenderer* renderer) override {
         const uint8_t viewSize = getViewSize(renderer);
-        char vbuf[viewSize + 1];
+        char* vbuf = new char[viewSize + 1];
         substring(value, view, viewSize, vbuf);
         vbuf[viewSize] = '\0';
         renderer->drawItem(text, vbuf);
+        delete[] vbuf;
     }
     bool process(LcdMenu* menu, const unsigned char command) override {
         MenuRenderer* renderer = menu->getRenderer();

--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -74,8 +74,8 @@ class ItemInput : public MenuItem {
      *
      * Effectively const, but initialized lately when renderer is injected.
      */
-    inline uint8_t getViewSize(MenuRenderer* renderer) {
-        return renderer->getMaxCols() - (strlen(text) + 2) - 1;
+    inline uint8_t getViewSize(MenuRenderer* renderer) const {
+        return renderer->getEffectiveCols() - strlen(text) - 1;
     };
 
   public:
@@ -130,18 +130,11 @@ class ItemInput : public MenuItem {
 
   protected:
     void draw(MenuRenderer* renderer) override {
-        uint8_t viewSize = getViewSize(renderer);
-        char* vbuf = new char[viewSize + 1];
+        const uint8_t viewSize = getViewSize(renderer);
+        char vbuf[viewSize + 1];
         substring(value, view, viewSize, vbuf);
         vbuf[viewSize] = '\0';
-
-        uint8_t maxCols = renderer->getMaxCols();
-        char buf[maxCols];
-        concat(text, ':', buf);
-        concat(buf, vbuf, buf);
-        renderer->drawItem(buf);
-
-        delete[] vbuf;  // Free allocated memory
+        renderer->drawItem(text, vbuf);
     }
     bool process(LcdMenu* menu, const unsigned char command) override {
         MenuRenderer* renderer = menu->getRenderer();
@@ -220,11 +213,14 @@ class ItemInput : public MenuItem {
             return;
         }
         cursor--;
-        if (cursor < view) {
+        uint8_t cursorCol = renderer->getCursorCol();
+        if (cursor <= view - 1) {
             view--;
             draw(renderer);
+        } else {
+            cursorCol--;
         }
-        renderer->moveCursor(renderer->getCursorCol() - 1, renderer->getCursorRow());
+        renderer->moveCursor(cursorCol, renderer->getCursorRow());
         renderer->drawBlinker();
         // Log
         printLog(F("ItemInput::left"), value);
@@ -238,11 +234,14 @@ class ItemInput : public MenuItem {
         }
         cursor++;
         uint8_t viewSize = getViewSize(renderer);
+        uint8_t cursorCol = renderer->getCursorCol();
         if (cursor > (view + viewSize - 1)) {
             view++;
             draw(renderer);
+        } else {
+            cursorCol++;
         }
-        renderer->moveCursor(renderer->getCursorCol() + 1, renderer->getCursorRow());
+        renderer->moveCursor(cursorCol, renderer->getCursorRow());
         renderer->drawBlinker();
         // Log
         printLog(F("ItemInput::right"), value);
@@ -256,12 +255,14 @@ class ItemInput : public MenuItem {
         }
         remove(value, cursor - 1, 1);
         cursor--;
-        if (cursor < view) {
-            view--;
-        }
         uint8_t cursorCol = renderer->getCursorCol();
+        if (view > 0) {
+            view--;
+        } else {
+            cursorCol--;
+        }
         draw(renderer);
-        renderer->moveCursor(cursorCol - 1, renderer->getCursorRow());
+        renderer->moveCursor(cursorCol, renderer->getCursorRow());
         renderer->drawBlinker();
         // Log
         printLog(F("ItemInput::backspace"), value);

--- a/src/ItemInputCharset.h
+++ b/src/ItemInputCharset.h
@@ -118,11 +118,13 @@ class ItemInputCharset : public ItemInput {
      */
     void abortCharEdit(MenuRenderer* renderer) {
         charEdit = false;
+        uint8_t cursorCol = renderer->getCursorCol();
         if (cursor < strlen(value)) {
             renderer->draw(value[cursor]);
         } else {
             renderer->draw(' ');
         }
+        renderer->moveCursor(cursorCol, renderer->getCursorRow());
         printLog(F("ItemInputCharset::abortCharEdit"));
     }
     /**

--- a/src/ItemInputCharset.h
+++ b/src/ItemInputCharset.h
@@ -110,7 +110,6 @@ class ItemInputCharset : public ItemInput {
                 return;
             }
         }
-        charsetPosition = -1;
     }
     /**
      * @brief Stop `char edit mode` and abort all mde changes.
@@ -159,7 +158,7 @@ class ItemInputCharset : public ItemInput {
      * @brief Show previous char from charset.
      */
     void showPreviousChar(MenuRenderer* renderer) {
-        if (charsetPosition == 0) {
+        if (charsetPosition <= 0) {
             charsetPosition = strlen(charset) - 1;
         } else {
             charsetPosition--;

--- a/src/ItemList.h
+++ b/src/ItemList.h
@@ -86,11 +86,7 @@ class ItemList : public MenuItem {
 
   protected:
     void draw(MenuRenderer* renderer) override {
-        uint8_t maxCols = renderer->getMaxCols();
-        char buf[maxCols];
-        concat(text, ':', buf);
-        concat(buf, getValue(), buf);
-        renderer->drawItem(buf);
+        renderer->drawItem(text, getValue());
     }
 
     bool process(LcdMenu* menu, const unsigned char command) override {

--- a/src/ItemRangeBase.h
+++ b/src/ItemRangeBase.h
@@ -108,11 +108,7 @@ class ItemRangeBase : public MenuItem {
 
   protected:
     void draw(MenuRenderer* renderer) override {
-        uint8_t maxCols = renderer->getMaxCols();
-        char buf[maxCols];
-        concat(text, ':', buf);
-        concat(buf, getDisplayValue(), buf);
-        renderer->drawItem(buf);
+        renderer->drawItem(text, getDisplayValue());
     }
 
     bool process(LcdMenu* menu, const unsigned char command) override {

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -83,11 +83,7 @@ class ItemToggle : public MenuItem {
     const char* getTextOff() { return this->textOff; }
 
     void draw(MenuRenderer* renderer) override {
-        uint8_t maxCols = renderer->getMaxCols();
-        char buf[maxCols];
-        concat(text, ':', buf);
-        concat(buf, enabled ? textOn : textOff, buf);
-        renderer->drawItem(buf);
+        renderer->drawItem(text, enabled ? textOn : textOff);
     };
 
   protected:

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -91,7 +91,7 @@ class MenuItem {
      * @param renderer The renderer to use for drawing.
      */
     virtual void draw(MenuRenderer* renderer) {
-        renderer->drawItem(text);
+        renderer->drawItem(text, NULL);
     };
 };
 

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -8,7 +8,12 @@ CharacterDisplayRenderer::CharacterDisplayRenderer(
     const uint8_t editCursorIcon,
     uint8_t* upArrow,
     uint8_t* downArrow)
-    : MenuRenderer(display, maxCols, maxRows), upArrow(upArrow), downArrow(downArrow), cursorIcon(cursorIcon), editCursorIcon(editCursorIcon) {}
+    : MenuRenderer(display, maxCols, maxRows),
+      upArrow(upArrow),
+      downArrow(downArrow),
+      cursorIcon(cursorIcon),
+      editCursorIcon(editCursorIcon),
+      availableColumns(maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0)) {}
 
 void CharacterDisplayRenderer::begin() {
     MenuRenderer::begin();
@@ -26,7 +31,7 @@ void CharacterDisplayRenderer::drawItem(const char* text, const char* value) {
         concat(buf, value, buf);
     }
 
-    buf[maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0)] = '\0';
+    buf[availableColumns] = '\0';
     uint8_t cursorCol = strlen(buf);
 
     padText(buf, buf);
@@ -81,8 +86,7 @@ void CharacterDisplayRenderer::appendIndicatorToText(const char* text, char* buf
 
 void CharacterDisplayRenderer::padText(const char* text, char* buf) {
     uint8_t textLength = strlen(text);
-    const uint8_t effectiveCols = maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0);
-    uint8_t spaces = (textLength > effectiveCols) ? 0 : effectiveCols - textLength;
+    uint8_t spaces = (textLength > availableColumns) ? 0 : availableColumns - textLength;
     spaces = constrain(spaces, 0, maxCols);
     strcpy(buf, text);
     memset(buf + textLength, ' ', spaces);
@@ -90,5 +94,5 @@ void CharacterDisplayRenderer::padText(const char* text, char* buf) {
 }
 
 uint8_t CharacterDisplayRenderer::getEffectiveCols() const {
-    return maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0) - (cursorIcon != 0 || editCursorIcon != 0 ? 1 : 0);
+    return availableColumns - (cursorIcon != 0 || editCursorIcon != 0 ? 1 : 0);
 }

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -16,11 +16,17 @@ void CharacterDisplayRenderer::begin() {
     static_cast<CharacterDisplayInterface*>(display)->createChar(2, downArrow);
 }
 
-void CharacterDisplayRenderer::drawItem(const char* text) {
+void CharacterDisplayRenderer::drawItem(const char* text, const char* value) {
     char buf[maxCols + 1];
 
     appendCursorToText(text, buf);
-    buf[calculateAvailableLength()] = '\0';
+
+    if (value != NULL) {
+        concat(buf, ":", buf);
+        concat(buf, value, buf);
+    }
+
+    buf[getEffectiveCols(false)] = '\0';
     uint8_t cursorCol = strlen(buf);
 
     padText(buf, buf);
@@ -75,13 +81,14 @@ void CharacterDisplayRenderer::appendIndicatorToText(const char* text, char* buf
 
 void CharacterDisplayRenderer::padText(const char* text, char* buf) {
     uint8_t textLength = strlen(text);
-    uint8_t spaces = (textLength > calculateAvailableLength()) ? 0 : calculateAvailableLength() - textLength;
+    const uint8_t effectiveCols = getEffectiveCols(false);
+    uint8_t spaces = (textLength > effectiveCols) ? 0 : effectiveCols - textLength;
     spaces = constrain(spaces, 0, maxCols);
     strcpy(buf, text);
     memset(buf + textLength, ' ', spaces);
     buf[textLength + spaces] = '\0';
 }
 
-uint8_t CharacterDisplayRenderer::calculateAvailableLength() {
-    return maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0);
+uint8_t CharacterDisplayRenderer::getEffectiveCols(bool withUpDownIndicators) const {
+    return maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0) - (withUpDownIndicators ? (cursorIcon != 0 || editCursorIcon != 0 ? 1 : 0) : 0);
 }

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -26,7 +26,7 @@ void CharacterDisplayRenderer::drawItem(const char* text, const char* value) {
         concat(buf, value, buf);
     }
 
-    buf[getEffectiveCols(false)] = '\0';
+    buf[maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0)] = '\0';
     uint8_t cursorCol = strlen(buf);
 
     padText(buf, buf);
@@ -81,7 +81,7 @@ void CharacterDisplayRenderer::appendIndicatorToText(const char* text, char* buf
 
 void CharacterDisplayRenderer::padText(const char* text, char* buf) {
     uint8_t textLength = strlen(text);
-    const uint8_t effectiveCols = getEffectiveCols(false);
+    const uint8_t effectiveCols = maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0);
     uint8_t spaces = (textLength > effectiveCols) ? 0 : effectiveCols - textLength;
     spaces = constrain(spaces, 0, maxCols);
     strcpy(buf, text);
@@ -89,6 +89,6 @@ void CharacterDisplayRenderer::padText(const char* text, char* buf) {
     buf[textLength + spaces] = '\0';
 }
 
-uint8_t CharacterDisplayRenderer::getEffectiveCols(bool withUpDownIndicators) const {
-    return maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0) - (withUpDownIndicators ? (cursorIcon != 0 || editCursorIcon != 0 ? 1 : 0) : 0);
+uint8_t CharacterDisplayRenderer::getEffectiveCols() const {
+    return maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0) - (cursorIcon != 0 || editCursorIcon != 0 ? 1 : 0);
 }

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -22,7 +22,7 @@ void CharacterDisplayRenderer::begin() {
 }
 
 void CharacterDisplayRenderer::drawItem(const char* text, const char* value) {
-    char buf[maxCols + 1];
+    char* buf = new char[maxCols + 1];
 
     appendCursorToText(text, buf);
 
@@ -40,6 +40,7 @@ void CharacterDisplayRenderer::drawItem(const char* text, const char* value) {
     display->setCursor(0, cursorRow);
     display->draw(buf);
     moveCursor(cursorCol, cursorRow);
+    delete[] buf;
 }
 
 void CharacterDisplayRenderer::draw(uint8_t byte) {

--- a/src/renderer/CharacterDisplayRenderer.h
+++ b/src/renderer/CharacterDisplayRenderer.h
@@ -64,7 +64,7 @@ class CharacterDisplayRenderer : public MenuRenderer {
      *
      * @return The number of columns available for displaying content.
      */
-    uint8_t getEffectiveCols(bool withUpDownIndicators = true) const override;
+    uint8_t getEffectiveCols() const override;
 
   public:
     /**

--- a/src/renderer/CharacterDisplayRenderer.h
+++ b/src/renderer/CharacterDisplayRenderer.h
@@ -56,15 +56,15 @@ class CharacterDisplayRenderer : public MenuRenderer {
     void padText(const char* text, char* buf);
 
     /**
-     * @brief Calculates the available length for display.
+     * @brief Calculates the available horizontal space for displaying content.
      *
      * This function computes the number of columns available for displaying content
-     * on the character display. It takes into account the presence of up and down
-     * arrows, which occupy one column if either is present.
+     * on the display. It takes into account the presence of up and down arrows, which
+     * occupy one column if either is present.
      *
      * @return The number of columns available for displaying content.
      */
-    uint8_t calculateAvailableLength();
+    uint8_t getEffectiveCols(bool withUpDownIndicators = true) const override;
 
   public:
     /**
@@ -106,7 +106,7 @@ class CharacterDisplayRenderer : public MenuRenderer {
      *
      * @param text The text of the menu item to be drawn.
      */
-    void drawItem(const char* text) override;
+    void drawItem(const char* text, const char* value) override;
     void draw(uint8_t byte) override;
     void drawBlinker() override;
     void clearBlinker() override;

--- a/src/renderer/CharacterDisplayRenderer.h
+++ b/src/renderer/CharacterDisplayRenderer.h
@@ -106,6 +106,7 @@ class CharacterDisplayRenderer : public MenuRenderer {
      * appending an indicator to the text, and finally drawing the text on the display.
      *
      * @param text The text of the menu item to be drawn.
+     * @param value The value of the menu item to be drawn.
      */
     void drawItem(const char* text, const char* value) override;
     void draw(uint8_t byte) override;

--- a/src/renderer/CharacterDisplayRenderer.h
+++ b/src/renderer/CharacterDisplayRenderer.h
@@ -25,6 +25,7 @@ class CharacterDisplayRenderer : public MenuRenderer {
     uint8_t* downArrow;
     const uint8_t cursorIcon;
     const uint8_t editCursorIcon;
+    const uint8_t availableColumns;
 
     /**
      * @brief Appends a cursor icon to the given text if the specified screen row is active.

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -71,6 +71,7 @@ class MenuRenderer {
     /**
      * @brief Draws an item on the display.
      * @param text Text of the item to be drawn.
+     * @param value Value of the item to be drawn.
      */
     virtual void drawItem(const char* text, const char* value) = 0;
 

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -147,7 +147,7 @@ class MenuRenderer {
      * @brief Calculates the available horizontal space for displaying content.
      * @return The horizontal space available for displaying content.
      */
-    virtual uint8_t getEffectiveCols(bool withUpDownIndicators = true) const = 0;
+    virtual uint8_t getEffectiveCols() const = 0;
 };
 
 #endif  // MENU_RENDERER_H

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -72,7 +72,7 @@ class MenuRenderer {
      * @brief Draws an item on the display.
      * @param text Text of the item to be drawn.
      */
-    virtual void drawItem(const char* text) = 0;
+    virtual void drawItem(const char* text, const char* value) = 0;
 
     /**
      * @brief Function to clear the blinker from the display.
@@ -142,6 +142,12 @@ class MenuRenderer {
      * @return Maximum number of columns.
      */
     uint8_t getMaxCols() const;
+
+    /**
+     * @brief Calculates the available horizontal space for displaying content.
+     * @return The horizontal space available for displaying content.
+     */
+    virtual uint8_t getEffectiveCols(bool withUpDownIndicators = true) const = 0;
 };
 
 #endif  // MENU_RENDERER_H

--- a/test/CharsetInput.test.yml
+++ b/test/CharsetInput.test.yml
@@ -6,11 +6,11 @@ steps:
   - simulate: enterButton-press
   - wait-serial: "#LOG# ItemInput::enterEditMode=0123456"
   - simulate: upButton-press
-  - wait-serial: "#LOG# ItemInputCharset::up=6"
+  - wait-serial: "#LOG# ItemInputCharset::up=9"
   - simulate: upButton-press
-  - wait-serial: "#LOG# ItemInputCharset::up=5"
+  - wait-serial: "#LOG# ItemInputCharset::up=8"
   - simulate: downButton-press
-  - wait-serial: "#LOG# ItemInputCharset::down=6"
+  - wait-serial: "#LOG# ItemInputCharset::down=9"
   - simulate: downButton-press
   - wait-serial: "#LOG# ItemInputCharset::down=0"
   - simulate: enterButton-press


### PR DESCRIPTION
## Description

This PR refactors the rendering logic by delegating the responsibility of rendering separators and values from individual items to the MenuRenderer. The changes include:

- Moving the render logic from each item to the `MenuRenderer`. Allowing the `MenuRenderer` to decide how to render the value, enabling customization of the separator.
- This refactor enhances the flexibility and maintainability of the rendering process by centralizing the rendering logic within the `MenuRenderer`.

### Changes

- Updated `MenuRenderer` to handle the rendering of separators and values.
- Removed rendering logic from individual items.
- Also adjusted the way `view` works in `ItemInput`, now when backspaces is pressed while the view is scrolled, it moves the characters to the right immediately until view is zero, this fixes the situation in previous releases where when I start deleting the characters and I reach the colon, I can't see the next character I am deleting.

## Screenshots/Video (if applicable)

https://github.com/user-attachments/assets/d0be9af5-04a2-400d-83e2-9905a3ff3461

---

### Checklist

#### General Requirements

- [x] I have kept this PR in draft until all the required tasks are completed.
- [x] I have reviewed the [contributing guidelines](/CONTRIBUTING.md) for this project.
- [x] I have tagged this PR with `breaking-change` if it introduces a breaking change.
- [x] I have checked that this PR does not introduce any breaking changes unless explicitly stated.
- [x] I have checked that changes generate no new warnings.
- [x] I have performed a self-review of my own code
- [x] I have built and tested **ALL** the examples to ensure that I haven't broken anything.

#### Refactor/Enhancement

- [x] **This PR is a code refactor.**
- [x] I have tagged this PR with `enhancement`.
- [x] I have made changes to the code that improve readability/performance/maintainability.
- [x] I have added documentation for the changes if necessary.
- [x] I have [generated](/docs/README.md) and reviewed the documentation locally if necessary.
