### PR TITLE
Display timeout works only when a draw operation happens

### DIFF
--- a/src/LcdMenu.cpp
+++ b/src/LcdMenu.cpp
@@ -19,6 +19,7 @@ bool LcdMenu::process(const unsigned char c) {
     if (!enabled) {
         return false;
     }
+    renderer.restartTimer();
     return screen->process(this, c);
 };
 

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -32,7 +32,6 @@ void MenuScreen::setCursor(MenuRenderer* renderer, uint8_t position) {
 }
 
 void MenuScreen::draw(MenuRenderer* renderer) {
-    renderer->restartTimer();
     for (uint8_t i = 0; i < renderer->maxRows; i++) {
         MenuItem* item = this->items[view + i];
         if (item == nullptr) {


### PR DESCRIPTION
Fixes #287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted timer restart mechanism in menu rendering to improve timing control and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->