### PR TITLE
Update WidgetBool process method to restrict value changes to edit mode

### DIFF
--- a/src/widget/WidgetBool.h
+++ b/src/widget/WidgetBool.h
@@ -41,11 +41,14 @@ class WidgetBool : public BaseWidgetValue<bool> {
      * @return true if command was handled, false otherwise
      */
     bool process(LcdMenu* menu, const unsigned char command) override {
-        if (command == UP || command == DOWN) {
-            value = !value;
-            LOG(F("WidgetToggle::toggle"), value);
-            handleChange();
-            return true;
+        MenuRenderer* renderer = menu->getRenderer();
+        if (renderer->isInEditMode()) {
+            if (command == UP || command == DOWN) {
+                value = !value;
+                LOG(F("WidgetToggle::toggle"), value);
+                handleChange();
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
Added a check for edit mode before processing UP/DOWN commands. This ensures that value toggling only happens when the menu is in edit mode, improving user experience and preventing unintended changes.

Fixes #294 

---

### Checklist

<!-- Note: Without all of these items checked the PR will not be reviewed. -->

#### General Requirements

- [x] I have kept this PR in draft until all the required tasks are completed.
- [x] I have reviewed the [contributing guidelines](https://github.com/forntoh/LcdMenu/blob/master/CONTRIBUTING.md) for this project.
- [x] I have tagged this PR with `breaking-change` if it introduces a breaking change.
- [x] I have checked that this PR does not introduce any breaking changes unless explicitly stated.
- [x] I have checked that changes generate no new warnings.
- [x] I have performed a self-review of my own code
- [ ] I have built and tested **ALL** the examples to ensure that I haven't broken anything.

#### Bug Fix

<!-- Delete this section if it doesn't apply to your PR. -->

- [x] **This PR is a bug fix.**
- [x] I have tagged this PR with `bugfix`.
- [x] I have added a link to the bug in the description.
- [ ] I have added tests that prove my fix is effective.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced widget toggle behavior by adding edit mode validation
	- Improved control mechanism for boolean widget interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->