### PR TITLE
Revert "Move shared deps into [env]"

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,28 @@
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
-[env]
+
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+extra_scripts = pre:.scripts/pio_config.py
+lib_deps = 
+	marcoschwartz/LiquidCrystal_I2C@^1.1.4
+	arduino-libraries/LiquidCrystal @ ^1.0.7
+	feilipu/FreeRTOS@^11.0.1-5
+	mprograms/SimpleRotary@^1.1.3
+	madleech/Button@^1.0.0
+	Wire
+	sstaub/SSD1803A_I2C@^1.0.2
+	adafruit/DHT sensor library@^1.4.6
+	adafruit/Adafruit Unified Sensor@^1.1.14
+
+[env:esp32]
+platform = espressif32
+board = esp32dev
+framework = arduino
+extra_scripts = pre:.scripts/pio_config.py
 lib_deps = 
 	marcoschwartz/LiquidCrystal_I2C@^1.1.4
 	arduino-libraries/LiquidCrystal @ ^1.0.7
@@ -17,17 +38,3 @@ lib_deps =
 	sstaub/SSD1803A_I2C@^1.0.2
 	adafruit/DHT sensor library@^1.4.6
 	adafruit/Adafruit Unified Sensor@^1.1.14
-extra_scripts = pre:.scripts/pio_config.py
-
-[env:uno]
-platform = atmelavr
-board = uno
-framework = arduino
-lib_deps = 
-	feilipu/FreeRTOS@^11.0.1-5
-
-[env:esp32]
-platform = espressif32
-board = esp32dev
-framework = arduino
-


### PR DESCRIPTION
Reverts forntoh/LcdMenu#301

Build no longer succeeds for uno

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
	- Updated PlatformIO configuration for Arduino Uno environment
	- Added new library dependencies for project development
	- Specified pre-build script for build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->