### PR TITLE
Fix unsigned integers may underflow in RangeWidget

### DIFF
--- a/src/widget/WidgetRange.h
+++ b/src/widget/WidgetRange.h
@@ -85,7 +85,7 @@ class WidgetRange : public BaseWidgetValue<T> {
      * @return true if decremented or reset (in case of cycle)
      */
     bool decrement() {
-        T newValue = (this->value - step < minValue) ? (cycle ? maxValue : minValue) : (this->value - step);
+        T newValue = (this->value < minValue + step) ? (cycle ? maxValue : minValue) : (this->value - step);
         if (newValue != this->value) {
             this->value = newValue;
             LOG(F("WidgetRange::decrement"), this->value);


### PR DESCRIPTION
Updated the decrement logic to prevent overflow by checking if the current value is less than the minimum plus step before performing the subtraction. This ensures safer calculations and maintains expected behavior during decrements.

Fixes #306


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the behavior of range controls to ensure more consistent value cycling when decrementing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->