### PR TITLE
Fix MenuScreen draw loop to prevent out-of-bounds access by limiting iteration to available items

### DIFF
--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -37,7 +37,7 @@ void MenuScreen::setCursor(MenuRenderer* renderer, uint8_t position) {
 }
 
 void MenuScreen::draw(MenuRenderer* renderer) {
-    for (uint8_t i = 0; i < renderer->maxRows; i++) {
+    for (uint8_t i = 0; i < renderer->maxRows && i < items.size(); i++) {
         MenuItem* item = this->items[view + i];
         if (item == nullptr) {
             break;


### PR DESCRIPTION
### Checklist

<!-- Note: Without all of these items checked the PR will not be reviewed. -->

#### General Requirements

- [x] I have kept this PR in draft until all the required tasks are completed.
- [x] I have reviewed the [contributing guidelines](https://github.com/forntoh/LcdMenu/blob/master/CONTRIBUTING.md) for this project.
- [x] I have tagged this PR with `breaking-change` if it introduces a breaking change.
- [x] I have checked that this PR does not introduce any breaking changes unless explicitly stated.
- [x] I have checked that changes generate no new warnings.
- [x] I have performed a self-review of my own code
- [x] I have built and tested **ALL** the examples to ensure that I haven't broken anything.

#### Bug Fix

<!-- Delete this section if it doesn't apply to your PR. -->

- [x] **This PR is a bug fix.**
- [x] I have tagged this PR with `bugfix`.
- [x] I have added a link to the bug in the description.
- [x] I have added tests that prove my fix is effective.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved menu display to handle scenarios with fewer available options, ensuring a more stable and reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->