### PR TITLE
Add clear method to MenuScreen for resetting menu items

### DIFF
--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -144,6 +144,10 @@ void MenuScreen::removeLastItem() {
     }
 }
 
+void MenuScreen::clear() {
+    items.clear();
+}
+
 void MenuScreen::poll(MenuRenderer* renderer, uint16_t pollInterval) {
     static unsigned long lastPollTime = 0;
     if (millis() - lastPollTime >= pollInterval) {

--- a/src/MenuScreen.h
+++ b/src/MenuScreen.h
@@ -111,6 +111,10 @@ class MenuScreen {
      * @brief Remove the last item from the menu.
      */
     void removeLastItem();
+    /**
+     * @brief Clear all items from the menu.
+     */
+    void clear();
 
     /**
      * @brief Get the number of items in the menu.


### PR DESCRIPTION
### Checklist

<!-- Note: Without all of these items checked the PR will not be reviewed. -->

#### General Requirements

- [x] I have kept this PR in draft until all the required tasks are completed.
- [x] I have reviewed the [contributing guidelines](https://github.com/forntoh/LcdMenu/blob/master/CONTRIBUTING.md) for this project.
- [x] I have tagged this PR with `breaking-change` if it introduces a breaking change.
- [x] I have checked that this PR does not introduce any breaking changes unless explicitly stated.
- [x] I have checked that changes generate no new warnings.
- [x] I have performed a self-review of my own code
- [x] I have built and tested **ALL** the examples to ensure that I haven't broken anything.

#### Refactor/Enhancement

<!-- Delete this section if it doesn't apply to your PR. -->

- [x] **This PR is a code refactor.**
- [ ] I have tagged this PR with `enhancement`.
- [x] I have made changes to the code that improve readability/performance/maintainability.
- [x] I have added documentation for the changes if necessary.
- [x] I have [generated](https://github.com/forntoh/LcdMenu/blob/master/docs/README.md) and reviewed the documentation locally if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a functionality for users to quickly remove all items from the menu display, allowing for an immediate fresh start when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->