### PR TITLE
Add check for edit mode in MenuScreen polling logic

### DIFF
--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -153,7 +153,7 @@ void MenuScreen::poll(MenuRenderer* renderer, uint16_t pollInterval) {
     if (millis() - lastPollTime >= pollInterval) {
         for (uint8_t i = 0; i < renderer->maxRows; i++) {
             MenuItem* item = this->items[view + i];
-            if (item == nullptr || !item->polling) continue;
+            if (item == nullptr || !item->polling || renderer->isInEditMode()) continue;
             syncIndicators(i, renderer);
             item->draw(renderer);
         }


### PR DESCRIPTION
Fixes #342 

### Checklist

<!-- Note: Without all of these items checked the PR will not be reviewed. -->

#### General Requirements

- [x] I have kept this PR in draft until all the required tasks are completed.
- [x] I have reviewed the [contributing guidelines](https://github.com/forntoh/LcdMenu/blob/master/CONTRIBUTING.md) for this project.
- [x] I have tagged this PR with `breaking-change` if it introduces a breaking change.
- [x] I have checked that this PR does not introduce any breaking changes unless explicitly stated.
- [x] I have checked that changes generate no new warnings.
- [x] I have performed a self-review of my own code
- [x] I have built and tested **ALL** the examples to ensure that I haven't broken anything.

#### Bug Fix

<!-- Delete this section if it doesn't apply to your PR. -->

- [x] **This PR is a bug fix.**
- [x] I have tagged this PR with `bugfix`.
- [x] I have added a link to the bug in the description.
- [x] I have added tests that prove my fix is effective.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted display behavior during edit mode to prevent non-essential items from appearing, delivering a cleaner editing interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->