### PR TITLE
Float printing for STM32

### DIFF
--- a/.github/workflows/compile-arduino.yml
+++ b/.github/workflows/compile-arduino.yml
@@ -59,9 +59,9 @@ jobs:
           - fqbn: arduino:samd:mkr1000
             type: mkr1000
             artifact-name-suffix: arduino-samd-mkr1000
-          - fqbn: STMicroelectronics:stm32:genericSTM32F103C8
+          - fqbn: STMicroelectronics:stm32:GenF1:pnum=BLUEPILL_F103C8
             type: stm32
-            artifact-name-suffix: stm32-stm32-genericstm32f103c8
+            artifact-name-suffix: STM32-stm32-GenF1
 
         include:
           # AVR boards

--- a/.github/workflows/compile-arduino.yml
+++ b/.github/workflows/compile-arduino.yml
@@ -61,7 +61,7 @@ jobs:
             artifact-name-suffix: arduino-samd-mkr1000
           - fqbn: STMicroelectronics:stm32:genericSTM32F103C8
             type: stm32
-            artifact-name-suffix: STM32-stm32-GenF1
+            artifact-name-suffix: stm32-stm32-genericstm32f103c8
 
         include:
           # AVR boards

--- a/.github/workflows/compile-arduino.yml
+++ b/.github/workflows/compile-arduino.yml
@@ -59,7 +59,7 @@ jobs:
           - fqbn: arduino:samd:mkr1000
             type: mkr1000
             artifact-name-suffix: arduino-samd-mkr1000
-          - fqbn: STMicroelectronics:stm32:GenF1
+          - fqbn: STMicroelectronics:stm32:genericSTM32F103C8
             type: stm32
             artifact-name-suffix: STM32-stm32-GenF1
 

--- a/src/utils/custom_printf.h
+++ b/src/utils/custom_printf.h
@@ -3,7 +3,7 @@
 #ifndef USE_CUSTOM_PRINTF
 // Platforms known to have full sprintf support
 #if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ESP8266) || \
-    defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_SAMD)
+    defined(ARDUINO_ARCH_SAMD)
 #define USE_CUSTOM_PRINTF 0
 #else
 #define USE_CUSTOM_PRINTF 1


### PR DESCRIPTION
## Description
Remove STM32 from the list of known to have full sprintf support, because apparently testing shows on bluePill there is no float support by default.
Re allows custom printf for STM32, that was turned off recently most likely by accident. Surprise is that STM32 bluepill_f103c8_128k do not have float printing support by default.

Fixes #349

### Checklist

<!-- Note: Without all of these items checked the PR will not be reviewed. -->

#### General Requirements

- [x] I have kept this PR in draft until all the required tasks are completed.
- [x] I have reviewed the [contributing guidelines](https://github.com/forntoh/LcdMenu/blob/master/CONTRIBUTING.md) for this project.
- [x] I have checked that this PR does not introduce any breaking changes unless explicitly stated.
- [x] I have checked that changes generate no new warnings.
- [x] I have performed a self-review of my own code

#### Bug Fix

<!-- Delete this section if it doesn't apply to your PR. -->

- [x] **This PR is a bug fix.**
- [x] I have tagged this PR with `bugfix`.
- [x] I have added a link to the bug in the description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enabled the custom printf implementation for STM32 platforms, improving compatibility and output formatting on these devices.
  - Updated STM32 board configuration to specify the Blue Pill variant for more precise compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->