### PR TITLE
Fix renderer timeout logic

### DIFF
--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -111,7 +111,7 @@ class MenuRenderer {
      * @brief Updates the display timer and hides the display if the timeout is reached.
      */
     virtual void updateTimer() {
-        if (millis() != startTime + DISPLAY_TIMEOUT) {
+        if (millis() - startTime < DISPLAY_TIMEOUT) {
             return;
         }
         LOG(F("MenuRenderer::timeout"));


### PR DESCRIPTION
## Summary
- Fixes #321 & #292 timer comparison in `MenuRenderer::updateTimer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved display timeout logic to ensure the display remains visible until the full timeout duration has elapsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->