### PR TITLE
Fix cursor bound in MenuScreen

### DIFF
--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -32,7 +32,7 @@ void MenuScreen::setCursor(MenuRenderer* renderer, uint8_t position) {
     } else if (constrained > (view + (viewSize - 1))) {
         view = constrained - (viewSize - 1);
     }
-    cursor = position;
+    cursor = constrained;
     draw(renderer);
 }
 


### PR DESCRIPTION
## Summary
- ensure setCursor uses constrained value

## Testing
- `bundle exec arduino_ci.rb --skip-examples-compilation` *(fails: undefined method `[]' for nil:NilClass)*
- `pio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68402a9ee050833284055c773343f539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu navigation by ensuring the cursor always stays within valid item boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->