### PR TITLE
Added isEnabled method in LcdMenu Class

### DIFF
--- a/src/LcdMenu.cpp
+++ b/src/LcdMenu.cpp
@@ -72,7 +72,6 @@ void LcdMenu::poll(uint16_t pollInterval) {
     }
     screen->poll(&renderer, pollInterval < 100 ? 100 : pollInterval);
 }
-
-bool LcdMenu::isEnabled(void) {
+bool LcdMenu::isEnabled() const {
     return enabled;
 }

--- a/src/LcdMenu.cpp
+++ b/src/LcdMenu.cpp
@@ -72,3 +72,7 @@ void LcdMenu::poll(uint16_t pollInterval) {
     }
     screen->poll(&renderer, pollInterval < 100 ? 100 : pollInterval);
 }
+
+bool LcdMenu::isEnabled(void) {
+    return enabled;
+}

--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -129,4 +129,9 @@ class LcdMenu {
      * @param pollInterval the interval to update the menu in milliseconds (default is 1000)
      */
     void poll(uint16_t pollInterval = 1000);
+    /**
+     * @brief Get the current status of the menu, enabled / disabled
+     * @return the value of private var 'enabled'
+     */
+    bool isEnabled(void);
 };

--- a/src/LcdMenu.h
+++ b/src/LcdMenu.h
@@ -133,5 +133,5 @@ class LcdMenu {
      * @brief Get the current status of the menu, enabled / disabled
      * @return the value of private var 'enabled'
      */
-    bool isEnabled(void);
+    bool isEnabled() const;
 };


### PR DESCRIPTION
Hi @forntoh,

This PR adds a method to get the enabled status of LcdMenu externally. 

The use-case that comes to mind:
1. User wants to display other info, not part of the menu, when the menu is inactive. a Dashboard for example.
2. The program may need to know if the menu is active, to only update the dashboard when menu is not shown. 
3. I initially kept track of the menu status using an external bool flag but this did not account for menus timing out.

Regards,
lekrom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to check if the menu is currently enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->