### PR TITLE
Fix spelling of padWithBlanks parameter

### DIFF
--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -23,7 +23,7 @@ void CharacterDisplayRenderer::begin() {
     }
 }
 
-void CharacterDisplayRenderer::drawItem(const char* text, const char* value, bool paddWithBlanks) {
+void CharacterDisplayRenderer::drawItem(const char* text, const char* value, bool padWithBlanks) {
     uint8_t cursorCol = 0;
     display->setCursor(cursorCol, cursorRow);
 
@@ -51,8 +51,8 @@ void CharacterDisplayRenderer::drawItem(const char* text, const char* value, boo
 
     uint8_t cursorColEnd = cursorCol;
 
-    // Fill remaining space with whitespace only when paddWithBlanks is true
-    if (paddWithBlanks) {
+    // Fill remaining space with whitespace only when padWithBlanks is true
+    if (padWithBlanks) {
         for (; cursorCol < availableColumns; cursorCol++) {
             display->draw(' ');
         }

--- a/src/renderer/CharacterDisplayRenderer.h
+++ b/src/renderer/CharacterDisplayRenderer.h
@@ -90,9 +90,9 @@ class CharacterDisplayRenderer : public MenuRenderer {
      *
      * @param text The text of the menu item to be drawn.
      * @param value The value of the menu item to be drawn.
-     * @param paddWithBlanks A flag indicating whether to pad the text with spaces.
+     * @param padWithBlanks A flag indicating whether to pad the text with spaces.
      */
-    void drawItem(const char* text, const char* value, bool paddWithBlanks) override;
+    void drawItem(const char* text, const char* value, bool padWithBlanks) override;
     void draw(uint8_t byte) override;
     void drawBlinker() override;
     void clearBlinker() override;

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -75,9 +75,9 @@ class MenuRenderer {
      * @brief Draws an item on the display.
      * @param text Text of the item to be drawn.
      * @param value Value of the item to be drawn.
-     * @param paddWithBlanks Flag indicating whether to pad the text with spaces.
+     * @param padWithBlanks Flag indicating whether to pad the text with spaces.
      */
-    virtual void drawItem(const char* text, const char* value, bool paddWithBlanks = true) = 0;
+    virtual void drawItem(const char* text, const char* value, bool padWithBlanks = true) = 0;
 
     /**
      * @brief Function to clear the blinker from the display.


### PR DESCRIPTION
## Summary
- fix parameter name to `padWithBlanks` in base and derived renderers
- update implementation in `CharacterDisplayRenderer`
- 
------
https://chatgpt.com/codex/tasks/task_e_6848923edeec8332ae1065093b942579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected a parameter name in user interface rendering methods to improve consistency and clarity in documentation and interface descriptions. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->