### PR TITLE
Add MenuScreen unit tests

### DIFF
--- a/test/MenuScreenTest.cpp
+++ b/test/MenuScreenTest.cpp
@@ -1,0 +1,75 @@
+#define protected public
+#include <MenuScreen.h>
+#undef protected
+#include <ArduinoUnitTests.h>
+#include <MenuItem.h>
+#include <display/DisplayInterface.h>
+#include <renderer/MenuRenderer.h>
+
+class StubDisplay : public DisplayInterface {
+  public:
+    void begin() override {}
+    void clear() override {}
+    void show() override {}
+    void hide() override {}
+    void draw(uint8_t) override {}
+    void draw(const char*) override {}
+    void setCursor(uint8_t, uint8_t) override {}
+    void setBacklight(bool) override {}
+};
+
+class StubRenderer : public MenuRenderer {
+  public:
+    StubDisplay display;
+    StubRenderer() : MenuRenderer(&display, 16, 2) {}
+
+    void draw(uint8_t) override {}
+    void drawItem(const char*, const char*, bool) override {}
+    void clearBlinker() override {}
+    void drawBlinker() override {}
+    uint8_t getEffectiveCols() const override { return maxCols; }
+};
+
+unittest(menu_screen_dynamic_item_management) {
+    MenuItem* i1 = ITEM_BASIC("One");
+    MenuItem* i2 = ITEM_BASIC("Two");
+    std::vector<MenuItem*> items = {i1, i2};
+    MenuScreen screen(items);
+    StubRenderer renderer;
+
+    assertEqual((size_t)2, screen.size());
+    assertEqual(i1, screen.getItemAt(0));
+
+    MenuItem* i3 = ITEM_BASIC("Three");
+    screen.addItem(i3);
+    assertEqual((size_t)3, screen.size());
+    assertEqual(i3, screen.getItemAt(2));
+    screen.setCursor(&renderer, 2);
+    assertEqual((uint8_t)2, screen.getCursor());
+
+    MenuItem* i4 = ITEM_BASIC("Four");
+    screen.addItemAt(1, i4);
+    assertEqual((size_t)4, screen.size());
+    assertEqual(i4, screen.getItemAt(1));
+    screen.setCursor(&renderer, 3);
+    assertEqual((uint8_t)3, screen.getCursor());
+
+    screen.removeItemAt(1);
+    assertEqual((size_t)3, screen.size());
+    screen.setCursor(&renderer, screen.getCursor());
+    assertEqual((uint8_t)2, screen.getCursor());
+    assertEqual(i3, screen.getItemAt(2));
+
+    screen.removeLastItem();
+    assertEqual((size_t)2, screen.size());
+    screen.setCursor(&renderer, screen.getCursor());
+    assertEqual((uint8_t)1, screen.getCursor());
+    assertEqual(i2, screen.getItemAt(1));
+
+    screen.clear();
+    assertEqual((size_t)0, screen.size());
+    screen.setCursor(&renderer, 0);
+    assertEqual((uint8_t)0, screen.getCursor());
+}
+
+unittest_main()

--- a/test/MenuScreenTest.cpp
+++ b/test/MenuScreenTest.cpp
@@ -59,17 +59,22 @@ unittest(menu_screen_dynamic_item_management) {
     screen.setCursor(&renderer, screen.getCursor());
     assertEqual((uint8_t)2, screen.getCursor());
     assertEqual(i3, screen.getItemAt(2));
+    delete i4; // removed item no longer used
 
     screen.removeLastItem();
     assertEqual((size_t)2, screen.size());
     screen.setCursor(&renderer, screen.getCursor());
     assertEqual((uint8_t)1, screen.getCursor());
     assertEqual(i2, screen.getItemAt(1));
+    delete i3; // removed last item
 
     screen.clear();
     assertEqual((size_t)0, screen.size());
     screen.setCursor(&renderer, 0);
     assertEqual((uint8_t)0, screen.getCursor());
+
+    delete i1;
+    delete i2;
 }
 
 unittest_main()


### PR DESCRIPTION
## Summary
- add a new MenuScreen test verifying dynamic item operations

## Testing
- `bundle exec arduino_ci.rb --skip-examples-compilation` *(fails: undefined method `[]' for nil:NilClass)*

------
https://chatgpt.com/codex/tasks/task_e_6849aa7e77008332a50c23fc6f36201a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new unit tests for dynamic item management in the menu screen, including adding, removing, and clearing items, as well as verifying cursor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->