### PR TITLE
Fix submenu crash when polling with few items

### DIFF
--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -151,7 +151,7 @@ void MenuScreen::clear() {
 void MenuScreen::poll(MenuRenderer* renderer, uint16_t pollInterval) {
     static unsigned long lastPollTime = 0;
     if (millis() - lastPollTime >= pollInterval) {
-        for (uint8_t i = 0; i < renderer->maxRows; i++) {
+        for (uint8_t i = 0; i < renderer->maxRows && (view + i) < items.size(); i++) {
             MenuItem* item = this->items[view + i];
             if (item == nullptr || !item->polling || renderer->isInEditMode()) continue;
             syncIndicators(i, renderer);


### PR DESCRIPTION
## Summary
- avoid out-of-bounds access in `MenuScreen::poll`

## Testing
- `bundle exec arduino_ci.rb --skip-examples-compilation` *(fails: undefined method `[]` for nil:NilClass)*

------
https://chatgpt.com/codex/tasks/task_e_6848889fb5c08332ab59e4bf52b4ac3c