### PR TITLE
Fix MenuScreen draw bounds

### DIFF
--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -37,7 +37,7 @@ void MenuScreen::setCursor(MenuRenderer* renderer, uint8_t position) {
 }
 
 void MenuScreen::draw(MenuRenderer* renderer) {
-    for (uint8_t i = 0; i < renderer->maxRows && i < items.size(); i++) {
+    for (uint8_t i = 0; i < renderer->maxRows && (view + i) < items.size(); i++) {
         MenuItem* item = this->items[view + i];
         if (item == nullptr) {
             break;

--- a/test/MenuScreenTest.cpp
+++ b/test/MenuScreenTest.cpp
@@ -94,16 +94,16 @@ unittest(menu_screen_draw_clamps_view) {
     MenuScreen screen(items);
     StubRenderer renderer;
 
-    screen.setCursor(&renderer, 4); // move cursor to last item, view becomes 3
+    screen.setCursor(&renderer, 4);  // move cursor to last item, view becomes 3
 
     screen.removeLastItem();
-    screen.removeLastItem(); // remove down to 3 items, view still 3
+    screen.removeLastItem();  // remove down to 3 items, view still 3
 
     screen.draw(&renderer);
 
     assertEqual((uint8_t)0, i1->drawCount);
     assertEqual((uint8_t)0, i2->drawCount);
-    assertEqual((uint8_t)0, i3->drawCount); // no items drawn but no crash
+    assertEqual((uint8_t)0, i3->drawCount);  // no items drawn but no crash
 
     delete i1;
     delete i2;

--- a/test/MenuScreenTest.cpp
+++ b/test/MenuScreenTest.cpp
@@ -30,6 +30,13 @@ class StubRenderer : public MenuRenderer {
     uint8_t getEffectiveCols() const override { return maxCols; }
 };
 
+class CountingItem : public MenuItem {
+  public:
+    uint8_t drawCount = 0;
+    CountingItem(const char* t) : MenuItem(t) {}
+    void draw(MenuRenderer*) override { drawCount++; }
+};
+
 unittest(menu_screen_dynamic_item_management) {
     MenuItem* i1 = ITEM_BASIC("One");
     MenuItem* i2 = ITEM_BASIC("Two");
@@ -75,6 +82,34 @@ unittest(menu_screen_dynamic_item_management) {
 
     delete i1;
     delete i2;
+}
+
+unittest(menu_screen_draw_clamps_view) {
+    CountingItem* i1 = new CountingItem("One");
+    CountingItem* i2 = new CountingItem("Two");
+    CountingItem* i3 = new CountingItem("Three");
+    CountingItem* i4 = new CountingItem("Four");
+    CountingItem* i5 = new CountingItem("Five");
+    std::vector<MenuItem*> items = {i1, i2, i3, i4, i5};
+    MenuScreen screen(items);
+    StubRenderer renderer;
+
+    screen.setCursor(&renderer, 4); // move cursor to last item, view becomes 3
+
+    screen.removeLastItem();
+    screen.removeLastItem(); // remove down to 3 items, view still 3
+
+    screen.draw(&renderer);
+
+    assertEqual((uint8_t)0, i1->drawCount);
+    assertEqual((uint8_t)0, i2->drawCount);
+    assertEqual((uint8_t)0, i3->drawCount); // no items drawn but no crash
+
+    delete i1;
+    delete i2;
+    delete i3;
+    delete i4;
+    delete i5;
 }
 
 unittest_main()


### PR DESCRIPTION
Fixes #354 

## Summary
- avoid accessing items outside of the view in `MenuScreen::draw`
- add regression test ensuring draw doesn't crash when view exceeds items

## Testing
- `g++ -std=c++0x -I$ARDUINO_CI_PATH/arduino -I$ARDUINO_CI_PATH/unittest -Isrc -Isrc/display -Isrc/renderer -Isrc/utils -Isrc/input -Isrc/widget -Itest test/ItemValue.cpp src/LcdMenu.cpp src/MenuScreen.cpp src/renderer/MenuRenderer.cpp src/renderer/CharacterDisplayRenderer.cpp src/utils/printf.c $ARDUINO_CI_PATH/arduino/Godmode.cpp $ARDUINO_CI_PATH/unittest/ArduinoUnitTests.cpp -o .arduino_ci/ItemValue`
- `g++ -std=c++0x -I$ARDUINO_CI_PATH/arduino -I$ARDUINO_CI_PATH/unittest -Isrc -Isrc/display -Isrc/renderer -Isrc/utils -Isrc/input -Isrc/widget -Itest test/LcdMenu.cpp src/LcdMenu.cpp src/MenuScreen.cpp src/renderer/MenuRenderer.cpp src/renderer/CharacterDisplayRenderer.cpp src/utils/printf.c $ARDUINO_CI_PATH/arduino/Godmode.cpp $ARDUINO_CI_PATH/unittest/ArduinoUnitTests.cpp -o .arduino_ci/LcdMenu`
- `g++ -std=c++0x -I$ARDUINO_CI_PATH/arduino -I$ARDUINO_CI_PATH/unittest -Isrc -Isrc/display -Isrc/renderer -Isrc/utils -Isrc/input -Isrc/widget -Itest test/MenuScreenTest.cpp src/LcdMenu.cpp src/MenuScreen.cpp src/renderer/MenuRenderer.cpp src/renderer/CharacterDisplayRenderer.cpp src/utils/printf.c $ARDUINO_CI_PATH/arduino/Godmode.cpp $ARDUINO_CI_PATH/unittest/ArduinoUnitTests.cpp -o .arduino_ci/MenuScreenTest`
- `g++ -std=c++0x -I$ARDUINO_CI_PATH/arduino -I$ARDUINO_CI_PATH/unittest -Isrc -Isrc/display -Isrc/renderer -Isrc/utils -Isrc/input -Isrc/widget -Itest test/utils.cpp src/LcdMenu.cpp src/MenuScreen.cpp src/renderer/MenuRenderer.cpp src/renderer/CharacterDisplayRenderer.cpp src/utils/printf.c $ARDUINO_CI_PATH/arduino/Godmode.cpp $ARDUINO_CI_PATH/unittest/ArduinoUnitTests.cpp -o .arduino_ci/utils`
- `.arduino_ci/MenuScreenTest`
- `.arduino_ci/ItemValue`
- `.arduino_ci/LcdMenu`
- `.arduino_ci/utils`
- `pio run`
- `wokwi-cli --elf .pio/build/uno/firmware.elf --scenario test/Basic.test.yml --timeout 1000` *(fails: Invalid scenario step key)*

------
https://chatgpt.com/codex/tasks/task_e_684a7cf4868083328d55bf087b54bcaa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu display to prevent errors or unexpected behavior when items are removed and the view is adjusted.

- **Tests**
  - Added a new unit test to ensure the menu correctly handles item removal without drawing out-of-bounds items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->