### PR TITLE
Implement feature #333

### DIFF
--- a/docs/source/overview/items/item-widget.rst
+++ b/docs/source/overview/items/item-widget.rst
@@ -21,6 +21,8 @@ ItemWidget has the following properties:
 ItemWidget can host one or more widgets.
 The widgets can be of different types and can be used to display different types of data.
 
+When editing a widget, pressing **BACK** restores the original value of the item instead of saving the changes.
+
 You can add widget items dynamically to the ItemWidget using :cpp:func:`BaseItemManyWidgets::addWidget`, :cpp:func:`BaseItemManyWidgets::addWidgetAt` functions or
 remove them using the :cpp:func:`BaseItemManyWidgets::removeWidget` function at runtime to update the widgets based on user input or other conditions.
 

--- a/src/BaseItemManyWidgets.h
+++ b/src/BaseItemManyWidgets.h
@@ -168,13 +168,14 @@ class BaseItemManyWidgets : public MenuItem {
                     left(renderer);
                     return true;
                 case BACK:
-                    back(renderer);
+                    cancel(renderer);
                     return true;
                 default:
                     return false;
             }
         }
         if (command == ENTER) {
+            for (auto* w : widgets) w->startEdit();
             renderer->setEditMode(true);
             draw(renderer);
             renderer->drawBlinker();
@@ -208,6 +209,16 @@ class BaseItemManyWidgets : public MenuItem {
         renderer->clearBlinker();
         draw(renderer);
         LOG(F("ItemWidget::exitEditMode"), this->text);
+    }
+
+    void cancel(MenuRenderer* renderer) {
+        renderer->setEditMode(false);
+        renderer->viewShift = 0;
+        for (auto* w : widgets) w->cancelEdit();
+        reset();
+        renderer->clearBlinker();
+        draw(renderer);
+        LOG(F("ItemWidget::cancelEditMode"), this->text);
     }
 };
 

--- a/src/widget/BaseWidget.h
+++ b/src/widget/BaseWidget.h
@@ -47,6 +47,10 @@ class BaseWidget {
      */
     virtual uint8_t draw(char* buffer, const uint8_t start = 0) = 0;
 
+    virtual void startEdit() {}
+
+    virtual void cancelEdit() {}
+
   public:
     virtual ~BaseWidget() = default;
 };

--- a/src/widget/WidgetBool.h
+++ b/src/widget/WidgetBool.h
@@ -16,6 +16,7 @@ class WidgetBool : public BaseWidgetValue<V> {
   protected:
     const char* textOn;
     const char* textOff;
+    bool originalValue;
 
   public:
     WidgetBool(
@@ -25,7 +26,10 @@ class WidgetBool : public BaseWidgetValue<V> {
         const char* format,
         const uint8_t cursorOffset,
         void (*callback)(const V&) = nullptr)
-        : BaseWidgetValue<V>(value, format, cursorOffset, callback), textOn(textOn), textOff(textOff) {}
+        : BaseWidgetValue<V>(value, format, cursorOffset, callback),
+          textOn(textOn),
+          textOff(textOff),
+          originalValue(static_cast<bool>(value)) {}
 
   protected:
     uint8_t draw(char* buffer, const uint8_t start) override {
@@ -50,6 +54,10 @@ class WidgetBool : public BaseWidgetValue<V> {
         }
         return false;
     }
+
+    void startEdit() { originalValue = static_cast<bool>(this->value); }
+
+    void cancelEdit() { this->value = originalValue; }
 };
 
 /**

--- a/src/widget/WidgetList.h
+++ b/src/widget/WidgetList.h
@@ -22,6 +22,7 @@ class WidgetList : public BaseWidgetValue<V> {
   protected:
     const bool cycle;
     const std::vector<T>& values;
+    V originalValue;
 
   public:
     WidgetList(
@@ -33,7 +34,8 @@ class WidgetList : public BaseWidgetValue<V> {
         void (*callback)(const V&))
         : BaseWidgetValue<V>(activePosition, format, cursorOffset, callback),
           cycle(cycle),
-          values(values) {}
+          values(values),
+          originalValue(static_cast<V>(activePosition)) {}
 
   protected:
     /**
@@ -95,6 +97,10 @@ class WidgetList : public BaseWidgetValue<V> {
         }
         return false;
     }
+
+    void startEdit() { originalValue = static_cast<V>(this->value); }
+
+    void cancelEdit() { this->value = originalValue; }
 };
 
 /**

--- a/src/widget/WidgetRange.h
+++ b/src/widget/WidgetRange.h
@@ -18,6 +18,7 @@ class WidgetRange : public BaseWidgetValue<V> {
     const T minValue;
     const T maxValue;
     const bool cycle;
+    T originalValue;
 
   public:
     WidgetRange(
@@ -33,7 +34,8 @@ class WidgetRange : public BaseWidgetValue<V> {
           step(step),
           minValue(min),
           maxValue(max),
-          cycle(cycle) {}
+          cycle(cycle),
+          originalValue(static_cast<T>(value)) {}
 
     /**
      * @brief Sets the value.
@@ -105,6 +107,10 @@ class WidgetRange : public BaseWidgetValue<V> {
         if (start >= ITEM_DRAW_BUFFER_SIZE) return 0;
         return snprintf(buffer + start, ITEM_DRAW_BUFFER_SIZE - start, this->format, static_cast<T>(this->value));
     }
+
+    void startEdit() { originalValue = static_cast<T>(this->value); }
+
+    void cancelEdit() { this->value = originalValue; }
 };
 
 /**

--- a/test/IntFloatValues.test.yml
+++ b/test/IntFloatValues.test.yml
@@ -19,6 +19,12 @@ steps:
   - wait-serial: "#LOG# WidgetRange::decrement=101"
   - simulate: backButton-press
   - wait-serial: "#LOG# ItemWidget::exitEditMode=Dist"
+  - simulate: enterButton-press
+  - wait-serial: "#LOG# ItemWidget::enterEditMode=Dist"
+  - simulate: upButton-press
+  - wait-serial: "#LOG# WidgetRange::increment=101"
+  - simulate: backButton-press
+  - wait-serial: "#LOG# ItemWidget::exitEditMode=Dist"
   - simulate: downButton-press
   - wait-serial: "#LOG# MenuScreen::down=2"
   - simulate: enterButton-press

--- a/test/List.test.yml
+++ b/test/List.test.yml
@@ -15,6 +15,12 @@ steps:
   - wait-serial: "#LOG# WidgetList::nextValue=3"
   - simulate: backButton-press
   - wait-serial: "#LOG# ItemWidget::exitEditMode=Color"
+  - simulate: enterButton-press
+  - wait-serial: "#LOG# ItemWidget::enterEditMode=Color"
+  - simulate: upButton-press
+  - wait-serial: "#LOG# WidgetList::nextValue=1"
+  - simulate: backButton-press
+  - wait-serial: "#LOG# ItemWidget::exitEditMode=Color"
   - simulate: downButton-press
   - wait-serial: "#LOG# MenuScreen::down=2"
   - simulate: enterButton-press


### PR DESCRIPTION
## Summary
- allow cancelling widget edits with BACK command
- document BACK behavior in ItemWidget docs
- update widget classes to track original values
- test scenarios for cancelling edits

## Testing
- `g++ -std=c++0x -I src -I test -I. test/utils.cpp test/LcdMenu.cpp test/MenuScreenTest.cpp test/ItemValue.cpp -o .arduino_ci/runTests && ./.arduino_ci/runTests > /tmp/unit_test.log && tail -n 20 /tmp/unit_test.log` *(fails: Arduino.h: No such file or directory)*
- `pio run` *(fails: undefined reference to `setup`)*
- `wokwi-cli --scenario test/IntFloatValues.test.yml` *(fails: firmware file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7b2938048332bb65f81d9d12caee