### PR TITLE
Add unselectable menu item

### DIFF
--- a/src/ItemLabel.h
+++ b/src/ItemLabel.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "MenuItem.h"
+
+/**
+ * @class ItemLabel
+ * @brief An unselectable menu item used for titles or separators.
+ */
+class ItemLabel : public MenuItem {
+  public:
+    explicit ItemLabel(const char* text) : MenuItem(text) {}
+
+    bool isSelectable() const override { return false; }
+};
+
+/**
+ * @brief Create a new unselectable label item.
+ *
+ * @param text The text to display for the item.
+ * @return MenuItem* The created item. Caller takes ownership of the returned pointer.
+ */
+inline MenuItem* ITEM_LABEL(const char* text) { return new ItemLabel(text); }

--- a/src/LcdMenu.cpp
+++ b/src/LcdMenu.cpp
@@ -12,7 +12,7 @@ void LcdMenu::setScreen(MenuScreen* screen) {
     LOG(F("LcdMenu::setScreen"));
     this->screen = screen;
     renderer.display->clear();
-    this->screen->draw(&renderer);
+    this->screen->setCursor(&renderer, this->screen->getCursor());
 }
 
 bool LcdMenu::process(const unsigned char c) {

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -71,6 +71,12 @@ class MenuItem {
         this->text = text;
     };
 
+
+    /**
+     * @brief Check if the item can be selected by the cursor.
+     */
+    virtual bool isSelectable() const { return true; }
+
     // Destructor
     virtual ~MenuItem() noexcept = default;
 

--- a/test/UnselectableItem.cpp
+++ b/test/UnselectableItem.cpp
@@ -1,0 +1,43 @@
+#include <ArduinoUnitTests.h>
+#include <ItemLabel.h>
+#include <MenuItem.h>
+#include <MenuScreen.h>
+#include <display/DisplayInterface.h>
+#include <renderer/MenuRenderer.h>
+
+class DummyDisplay : public DisplayInterface {
+  public:
+    void begin() override {}
+    void clear() override {}
+    void show() override {}
+    void hide() override {}
+    void draw(uint8_t) override {}
+    void draw(const char*) override {}
+    void setCursor(uint8_t, uint8_t) override {}
+    void setBacklight(bool) override {}
+};
+
+class DummyRenderer : public MenuRenderer {
+  public:
+    DummyDisplay display;
+    DummyRenderer() : MenuRenderer(&display, 16, 2) {}
+    void draw(uint8_t) override {}
+    void drawItem(const char*, const char*, bool) override {}
+    void clearBlinker() override {}
+    void drawBlinker() override {}
+    uint8_t getEffectiveCols() const override { return maxCols; }
+};
+
+unittest(cursor_skips_unselectable_items) {
+    std::vector<MenuItem*> items = {ITEM_LABEL("Title"), ITEM_BASIC("First"), ITEM_BASIC("Second")};
+    MenuScreen screen(items);
+    DummyRenderer renderer;
+    screen.setCursor(&renderer, 0);
+    assertEqual(1, screen.getCursor());
+    screen.down(&renderer);
+    assertEqual(2, screen.getCursor());
+    screen.up(&renderer);
+    assertEqual(1, screen.getCursor());
+}
+
+unittest_main()


### PR DESCRIPTION
## Summary
- add `ItemLabel` to represent unselectable text items
- remove `selectable` flag from `MenuItem`
- override `isSelectable` in `ItemLabel`
- revert accidental changes to `keywords.txt`

## Testing
- `g++ -std=c++0x test/LcdMenu.cpp -I src -I test -o .arduino_ci/LcdMenu_test` *(fails: Arduino.h: No such file or directory)*
- `g++ -std=c++0x test/UnselectableItem.cpp -I src -I test -o .arduino_ci/UnselectableItem_test` *(fails: ArduinoUnitTests.h: No such file or directory)*
- `LOCAL_BUILD=1 pio run` *(fails: undefined reference to `setup`)*
- `wokwi-cli --scenario test/Basic.test.yml --timeout 1000` *(fails: firmware file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7c41b61083328de663873e4092d7