### PR TITLE
Add destructor for arrow icons

### DIFF
--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -15,6 +15,11 @@ CharacterDisplayRenderer::CharacterDisplayRenderer(
       editCursorIcon(editCursorIcon),
       availableColumns(maxCols - (upArrow != NULL || downArrow != NULL ? 1 : 0)) {}
 
+CharacterDisplayRenderer::~CharacterDisplayRenderer() {
+    delete[] upArrow;
+    delete[] downArrow;
+}
+
 void CharacterDisplayRenderer::begin() {
     MenuRenderer::begin();
     if (upArrow != NULL && downArrow != NULL) {

--- a/src/renderer/CharacterDisplayRenderer.h
+++ b/src/renderer/CharacterDisplayRenderer.h
@@ -77,6 +77,14 @@ class CharacterDisplayRenderer : public MenuRenderer {
         uint8_t* downArrow = new uint8_t[8]{0x04, 0x04, 0x04, 0x04, 0x04, 0x1F, 0x0E, 0x04});
 
     /**
+     * @brief Destructor.
+     *
+     * Frees the memory used by the arrow icons. The renderer assumes ownership
+     * of the upArrow and downArrow arrays, so they must not be freed elsewhere.
+     */
+    virtual ~CharacterDisplayRenderer();
+
+    /**
      * @brief Initializes the renderer and creates custom characters on the display.
      */
     void begin() override;


### PR DESCRIPTION
## Summary
- add destructor to `CharacterDisplayRenderer`
- document ownership of `upArrow` and `downArrow`

## Testing
- `LOCAL_BUILD=1 pio run`
- `g++ -std=c++0x -I src -I test -I$ARDUINO_CI_DIR/cpp/arduino -I$ARDUINO_CI_DIR/cpp/unittest $ARDUINO_CI_DIR/cpp/unittest/ArduinoUnitTests.cpp $ARDUINO_CI_DIR/cpp/arduino/Arduino.cpp $ARDUINO_CI_DIR/cpp/arduino/Godmode.cpp src/LcdMenu.cpp src/MenuScreen.cpp src/renderer/CharacterDisplayRenderer.cpp src/renderer/MenuRenderer.cpp src/utils/printf.c test/ItemValue.cpp -o .arduino_ci/ItemValue && ./.arduino_ci/ItemValue`
- `g++ -std=c++0x -I src -I test -I$ARDUINO_CI_DIR/cpp/arduino -I$ARDUINO_CI_DIR/cpp/unittest $ARDUINO_CI_DIR/cpp/unittest/ArduinoUnitTests.cpp $ARDUINO_CI_DIR/cpp/arduino/Arduino.cpp $ARDUINO_CI_DIR/cpp/arduino/Godmode.cpp src/LcdMenu.cpp src/MenuScreen.cpp src/renderer/CharacterDisplayRenderer.cpp src/renderer/MenuRenderer.cpp src/utils/printf.c test/MenuScreenTest.cpp -o .arduino_ci/MenuScreenTest && ./.arduino_ci/MenuScreenTest`
- `g++ -std=c++0x -I src -I test -I$ARDUINO_CI_DIR/cpp/arduino -I$ARDUINO_CI_DIR/cpp/unittest $ARDUINO_CI_DIR/cpp/unittest/ArduinoUnitTests.cpp $ARDUINO_CI_DIR/cpp/arduino/Arduino.cpp $ARDUINO_CI_DIR/cpp/arduino/Godmode.cpp src/LcdMenu.cpp src/MenuScreen.cpp src/renderer/CharacterDisplayRenderer.cpp src/renderer/MenuRenderer.cpp src/utils/printf.c test/LcdMenu.cpp -o .arduino_ci/LcdMenu && ./.arduino_ci/LcdMenu`
- `wokwi-cli --timeout 1000 --scenario test/Basic.test.yml` *(fails: Invalid scenario step key)*

------
https://chatgpt.com/codex/tasks/task_e_684dfd3d123c8332945b3be02a9fbfd2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory management to prevent potential memory leaks when removing character display elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->