### PR TITLE
Fix memory leak in ItemInputCharset

### DIFF
--- a/src/ItemInputCharset.h
+++ b/src/ItemInputCharset.h
@@ -137,6 +137,7 @@ class ItemInputCharset : public ItemInput {
         } else {
             char* buf = new char[length + 2];
             concat(value, charset[charsetPosition], buf);
+            delete[] value;
             value = buf;
         }
         abortCharEdit(renderer);


### PR DESCRIPTION
## Summary
- prevent memory leak in `ItemInputCharset::commitCharEdit`

## Testing
- `pio run`
- `g++ -std=c++0x` unit tests
- `wokwi-cli` (fails: Invalid scenario step key)

------
https://chatgpt.com/codex/tasks/task_e_684dfe1b11048332b8748fd1d9f96122