### PR TITLE
Make edit mode global across menu items

### DIFF
--- a/examples/UseByRef/UseByRef.ino
+++ b/examples/UseByRef/UseByRef.ino
@@ -2,6 +2,7 @@
 #include <ItemList.h>
 #include <ItemRange.h>
 #include <LcdMenu.h>
+#include <MenuItem.h>
 #include <MenuScreen.h>
 #include <display/LiquidCrystal_I2CAdapter.h>
 #include <input/KeyboardAdapter.h>
@@ -71,7 +72,7 @@ void loop() {
     menu.poll();
     unsigned long now = millis();
     if (now - last > 1000) {
-        if (!menu.getRenderer()->isInEditMode()) {
+        if (!MenuItem::isEditing()) {
             hour++;
             hour %= 24;
             day++;

--- a/src/BaseItemManyWidgets.h
+++ b/src/BaseItemManyWidgets.h
@@ -114,7 +114,7 @@ class BaseItemManyWidgets : public MenuItem {
 
         for (uint8_t i = 0; i < widgets.size(); i++) {
             index += widgets[i]->draw(buf, index);
-            if (i == activeWidget && renderer->isInEditMode()) {
+            if (i == activeWidget && MenuItem::isEditing()) {
                 // Calculate the available space for the widgets after the text
                 size_t v_size = renderer->getEffectiveCols() - strlen(text) - 1;
                 // Adjust the view shift to ensure the active widget is visible
@@ -127,7 +127,7 @@ class BaseItemManyWidgets : public MenuItem {
         }
         renderer->drawItem(text, buf);
 
-        if (renderer->isInEditMode()) {
+        if (MenuItem::isEditing()) {
             renderer->moveCursor(cursorCol, renderer->getCursorRow());
         }
     }
@@ -157,7 +157,7 @@ class BaseItemManyWidgets : public MenuItem {
      */
     bool process(LcdMenu* menu, const unsigned char command) override {
         MenuRenderer* renderer = menu->getRenderer();
-        if (renderer->isInEditMode()) {
+        if (MenuItem::isEditing()) {
             if (widgets[activeWidget]->process(menu, command)) {
                 draw(renderer);
                 return true;
@@ -186,7 +186,7 @@ class BaseItemManyWidgets : public MenuItem {
         if (command == ENTER) {
             for (auto* w : widgets)
                 if (w) w->startEdit();
-            renderer->setEditMode(true);
+            MenuItem::beginEdit();
             draw(renderer);
             renderer->drawBlinker();
             LOG(F("ItemWidget::enterEditMode"), this->text);
@@ -212,7 +212,7 @@ class BaseItemManyWidgets : public MenuItem {
     }
 
     void back(MenuRenderer* renderer) {
-        renderer->setEditMode(false);
+        MenuItem::endEdit();
         renderer->viewShift = 0;
         reset();
         handleCommit();
@@ -222,7 +222,7 @@ class BaseItemManyWidgets : public MenuItem {
     }
 
     void cancel(MenuRenderer* renderer) {
-        renderer->setEditMode(false);
+        MenuItem::endEdit();
         renderer->viewShift = 0;
         for (auto* w : widgets)
             if (w) w->cancelEdit();

--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -123,7 +123,7 @@ class ItemInput : public MenuItem {
     }
     bool process(LcdMenu* menu, const unsigned char command) override {
         MenuRenderer* renderer = menu->getRenderer();
-        if (renderer->isInEditMode()) {
+        if (MenuItem::isEditing()) {
             if (isprint(command)) {
                 typeChar(renderer, command);
                 return true;
@@ -174,7 +174,7 @@ class ItemInput : public MenuItem {
             view = length - (viewSize - 1);
         }
         // Redraw
-        renderer->setEditMode(true);
+        MenuItem::beginEdit();
         draw(renderer);
         renderer->drawBlinker();
         // Log
@@ -182,7 +182,7 @@ class ItemInput : public MenuItem {
     };
     void back(MenuRenderer* renderer) {
         renderer->clearBlinker();
-        renderer->setEditMode(false);
+        MenuItem::endEdit();
         // Move view to 0 and redraw before exit
         cursor = 0;
         view = 0;

--- a/src/ItemInputCharset.h
+++ b/src/ItemInputCharset.h
@@ -38,7 +38,7 @@ class ItemInputCharset : public ItemInput {
   protected:
     bool process(LcdMenu* menu, const unsigned char command) override {
         MenuRenderer* renderer = menu->getRenderer();
-        if (renderer->isInEditMode()) {
+        if (MenuItem::isEditing()) {
             switch (command) {
                 case ENTER:
                     if (charEdit) {

--- a/src/MenuItem.cpp
+++ b/src/MenuItem.cpp
@@ -1,0 +1,7 @@
+#include "MenuItem.h"
+
+bool MenuItem::_isEditing = false;
+
+bool MenuItem::isEditing() { return _isEditing; }
+void MenuItem::beginEdit() { _isEditing = true; }
+void MenuItem::endEdit() { _isEditing = false; }

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -53,7 +53,12 @@ class MenuItem {
     const char* text = NULL;
     bool polling = false;
 
+    static bool _isEditing;
+
   public:
+    static bool isEditing();
+    static void beginEdit();
+    static void endEdit();
     MenuItem(const char* text) : text(text) {}
     /**
      * @brief Get the text of the item

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -181,7 +181,7 @@ void MenuScreen::poll(MenuRenderer* renderer, uint16_t pollInterval) {
     if (millis() - lastPollTime >= pollInterval) {
         for (uint8_t i = 0; i < renderer->maxRows && (view + i) < items.size(); i++) {
             MenuItem* item = this->items[view + i];
-            if (item == nullptr || !item->polling || renderer->isInEditMode()) continue;
+            if (item == nullptr || !item->polling || MenuItem::isEditing()) continue;
             syncIndicators(i, renderer);
             item->draw(renderer);
         }

--- a/src/input/SimpleRotaryAdapter.h
+++ b/src/input/SimpleRotaryAdapter.h
@@ -23,6 +23,7 @@
 #endif
 //
 #include "InputInterface.h"
+#include "MenuItem.h"
 #include <SimpleRotary.h>
 
 /**
@@ -85,7 +86,8 @@ class SimpleRotaryAdapter : public InputInterface {
         }
 
         // Check if the doublePressThreshold has elapsed for pending enter action
-        if ((!menu->getRenderer()->isInEditMode() && pendingEnter) || (pendingEnter && (currentTime - lastPressTime >= DOUBLE_PRESS_THRESHOLD))) {
+        if ((!MenuItem::isEditing() && pendingEnter) ||
+            (pendingEnter && (currentTime - lastPressTime >= DOUBLE_PRESS_THRESHOLD))) {
             menu->process(ENTER);  // Call ENTER action (short press)
             pendingEnter = false;
         }

--- a/src/renderer/CharacterDisplayRenderer.cpp
+++ b/src/renderer/CharacterDisplayRenderer.cpp
@@ -1,4 +1,5 @@
 #include "CharacterDisplayRenderer.h"
+#include "MenuItem.h"
 
 CharacterDisplayRenderer::CharacterDisplayRenderer(
     CharacterDisplayInterface* display,
@@ -34,7 +35,7 @@ void CharacterDisplayRenderer::drawItem(const char* text, const char* value, boo
 
     // Draw cursor or empty space based on focus and edit mode
     if (cursorIcon != 0 || editCursorIcon != 0) {
-        display->draw(hasFocus ? (inEditMode ? editCursorIcon : cursorIcon) : ' ');
+        display->draw(hasFocus ? (MenuItem::isEditing() ? editCursorIcon : cursorIcon) : ' ');
         cursorCol++;
     }
 

--- a/src/renderer/MenuRenderer.cpp
+++ b/src/renderer/MenuRenderer.cpp
@@ -1,4 +1,5 @@
 #include "MenuRenderer.h"
+#include "MenuItem.h"
 
 MenuRenderer::MenuRenderer(DisplayInterface* display, uint8_t maxCols, uint8_t maxRows)
     : maxCols(maxCols), maxRows(maxRows), display(display) {}
@@ -13,19 +14,10 @@ void MenuRenderer::moveCursor(uint8_t cursorCol, uint8_t cursorRow) {
     this->cursorRow = cursorRow;
 }
 
-void MenuRenderer::setEditMode(bool inEditMode) {
-    if (this->inEditMode != inEditMode) {
-        this->inEditMode = inEditMode;
-        moveCursor(0, cursorRow);
-    }
-}
-
 void MenuRenderer::restartTimer() {
     this->startTime = millis();
     display->show();
 }
-
-bool MenuRenderer::isInEditMode() const { return inEditMode; }
 
 uint8_t MenuRenderer::getCursorCol() const { return cursorCol; }
 

--- a/src/renderer/MenuRenderer.cpp
+++ b/src/renderer/MenuRenderer.cpp
@@ -1,5 +1,4 @@
 #include "MenuRenderer.h"
-#include "MenuItem.h"
 
 MenuRenderer::MenuRenderer(DisplayInterface* display, uint8_t maxCols, uint8_t maxRows)
     : maxCols(maxCols), maxRows(maxRows), display(display) {}

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -37,8 +37,6 @@ class MenuRenderer {
     uint8_t cursorCol;
     uint8_t cursorRow;
 
-    bool inEditMode;
-
     unsigned long startTime = 0;
 
   public:
@@ -97,12 +95,6 @@ class MenuRenderer {
     virtual void moveCursor(uint8_t cursorCol, uint8_t cursorRow);
 
     /**
-     * @brief Sets the edit mode for the menu.
-     * @param inEditMode Flag indicating whether to enter or exit edit mode.
-     */
-    void setEditMode(bool inEditMode);
-
-    /**
      * @brief Restarts the display timer and shows the display.
      */
     virtual void restartTimer();
@@ -117,12 +109,6 @@ class MenuRenderer {
         LOG(F("MenuRenderer::timeout"));
         display->hide();
     }
-
-    /**
-     * @brief Checks if the menu is in edit mode.
-     * @return True if in edit mode, false otherwise.
-     */
-    bool isInEditMode() const;
 
     /**
      * @brief Gets the current column position of the cursor.

--- a/test/LcdMenu.cpp
+++ b/test/LcdMenu.cpp
@@ -6,6 +6,7 @@
 #include <ItemCommand.h>
 #include <ItemLabel.h>
 #include <ItemToggle.h>
+#include <MenuItem.h>
 #include <display/DisplayInterface.h>
 #include <renderer/MenuRenderer.h>
 
@@ -116,7 +117,7 @@ unittest(clear_command_empties_input_and_resets_cursor) {
     assertEqual("", item.getValue());
     assertEqual((uint8_t)0, item.cursor);
     assertEqual((uint8_t)0, item.view);
-    assertTrue(renderer.isInEditMode());
+    assertTrue(MenuItem::isEditing());
 }
 
 unittest(hide_disables_and_clears_display) {


### PR DESCRIPTION
## Summary
- store edit mode as a static variable in `MenuItem`
- update renderer code to use the global edit mode flag
- remove redundant edit-mode helpers from `MenuRenderer`
- update widgets and examples for new API

## Testing
- `g++ -std=c++0x test/utils.cpp test/LcdMenu.cpp test/ItemValue.cpp test/UnselectableItem.cpp test/MenuScreenTest.cpp -I src -I test -o .arduino_ci/tests.out` *(fails: Arduino headers missing)*
- `pio run` *(fails: undefined reference to `setup`/`loop`)*
- `wokwi-cli --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c369853888332875ee095da3f4ba3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized edit-mode management into a single shared mechanism for the menu system.
  * Updated all renderers, input handlers, screens, and widgets to use the unified edit-state API.
  * Tests adjusted to reflect the new centralized edit-state access; user-facing behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->