### PR TITLE
ci: scope ST7920 compile checks to ESP32

### DIFF
--- a/.github/workflows/compile-arduino.yml
+++ b/.github/workflows/compile-arduino.yml
@@ -43,6 +43,11 @@ jobs:
 
       SKETCHES_REPORTS_PATH: sketches-reports
 
+      # Board-scoped sketches are appended at runtime in "Prepare sketch paths"
+      # to avoid compiling hardware-specific examples on incompatible targets.
+      ESP32_ONLY_SKETCH_PATHS: |
+        - examples/ST7920_SPI
+
     strategy:
       fail-fast: false
       matrix:
@@ -114,6 +119,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Prepare sketch paths
+        shell: bash
+        run: |
+          {
+            echo "COMPILE_SKETCH_PATHS<<EOF"
+            echo "${{ matrix.sketch-paths }}"
+            echo "${{ env.UNIVERSAL_SKETCH_PATHS }}"
+
+            # ST7920_SPI is hardware-specific. Compile it only for ESP32 jobs
+            # and only when the example exists on the current branch.
+            if [[ "${{ matrix.board.type }}" == "esp32" && -d "examples/ST7920_SPI" ]]; then
+              echo "${{ env.ESP32_ONLY_SKETCH_PATHS }}"
+            fi
+
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Compile sketches
         uses: arduino/compile-sketches@v1
         with:
@@ -123,9 +145,7 @@ jobs:
           libraries: |
             ${{ env.UNIVERSAL_LIBRARIES }}
             ${{ matrix.libraries }}
-          sketch-paths: |
-            ${{ matrix.sketch-paths }}
-            ${{ env.UNIVERSAL_SKETCH_PATHS }}
+          sketch-paths: ${{ env.COMPILE_SKETCH_PATHS }}
           enable-deltas-report: true
           enable-warnings-report: true
 

--- a/docs/source/overview/rendering/index.rst
+++ b/docs/source/overview/rendering/index.rst
@@ -25,3 +25,8 @@ Here are some that would be cool to have:
 - Web renderer
 - TFT renderer
 - OLED renderer
+
+.. note::
+
+    CI compiles hardware-specific rendering examples only on compatible board
+    jobs. For example, ``examples/ST7920_SPI`` is compiled on ESP32 jobs.


### PR DESCRIPTION
## Summary
- Route board-scoped example paths through a new `Prepare sketch paths` step in `compile-arduino.yml` so hardware-specific sketches can be conditionally included.
- Compile `examples/ST7920_SPI` only for ESP32 jobs (and only when the example exists on the branch), while preserving universal sketch compilation for all boards.
- Add a rendering docs note describing that CI compiles hardware-specific examples only on compatible board jobs.

## Verification
- Workflow/config and docs only change; no unit-test or runtime code paths were modified in this iteration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on how continuous integration compiles hardware-specific rendering examples exclusively on compatible board jobs.

* **Chores**
  * Improved CI/CD workflow to conditionally include hardware-specific example sketches in compilation based on target board type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->