### PR TITLE
refactor: add RTTI-free renderer extension core

### DIFF
--- a/docs/source/overview/rendering/index.rst
+++ b/docs/source/overview/rendering/index.rst
@@ -30,3 +30,14 @@ Here are some that would be cool to have:
 
     CI compiles hardware-specific rendering examples only on compatible board
     jobs. For example, ``examples/ST7920_SPI`` is compiled on ESP32 jobs.
+
+Renderer extension hooks
+------------------------
+
+Advanced renderers can expose optional capabilities through
+``MenuRenderer::queryExtension()``. Menu items can similarly expose optional
+capabilities through ``MenuItem::queryCapability()``.
+
+This extension model keeps the base APIs small for character displays, while
+still allowing specialized renderers to opt into features such as explicit
+frame lifecycle hooks.

--- a/src/LcdMenu.cpp
+++ b/src/LcdMenu.cpp
@@ -1,4 +1,11 @@
 #include "LcdMenu.h"
+#include "renderer/FrameLifecycleRenderer.h"
+
+namespace {
+FrameLifecycleRenderer* frameLifecycle(MenuRenderer& renderer) {
+    return static_cast<FrameLifecycleRenderer*>(renderer.queryExtension(FrameLifecycleRenderer::extensionId()));
+}
+}  // namespace
 
 MenuRenderer* LcdMenu::getRenderer() {
     return &renderer;
@@ -13,6 +20,11 @@ void LcdMenu::setScreen(MenuScreen* screen) {
     this->screen = screen;
     renderer.display->clear();
     this->screen->reset(&renderer);
+
+    FrameLifecycleRenderer* frame = frameLifecycle(renderer);
+    if (frame != NULL) {
+        frame->endFrame();
+    }
 }
 
 bool LcdMenu::process(const unsigned char c) {
@@ -20,7 +32,16 @@ bool LcdMenu::process(const unsigned char c) {
         return false;
     }
     renderer.restartTimer();
-    return screen->process(this, c);
+    bool handled = screen->process(this, c);
+
+    if (handled) {
+        FrameLifecycleRenderer* frame = frameLifecycle(renderer);
+        if (frame != NULL) {
+            frame->endFrame();
+        }
+    }
+
+    return handled;
 };
 
 void LcdMenu::reset() {
@@ -42,6 +63,11 @@ void LcdMenu::show() {
     enabled = true;
     renderer.display->clear();
     screen->draw(&renderer);
+
+    FrameLifecycleRenderer* frame = frameLifecycle(renderer);
+    if (frame != NULL) {
+        frame->endFrame();
+    }
 }
 
 uint8_t LcdMenu::getCursor() {
@@ -64,6 +90,11 @@ void LcdMenu::refresh() {
         return;
     }
     screen->draw(&renderer);
+
+    FrameLifecycleRenderer* frame = frameLifecycle(renderer);
+    if (frame != NULL) {
+        frame->endFrame();
+    }
 }
 
 void LcdMenu::poll(uint16_t pollInterval) {

--- a/src/LcdMenu.cpp
+++ b/src/LcdMenu.cpp
@@ -20,11 +20,6 @@ void LcdMenu::setScreen(MenuScreen* screen) {
     this->screen = screen;
     renderer.display->clear();
     this->screen->reset(&renderer);
-
-    FrameLifecycleRenderer* frame = frameLifecycle(renderer);
-    if (frame != NULL) {
-        frame->endFrame();
-    }
 }
 
 bool LcdMenu::process(const unsigned char c) {
@@ -33,14 +28,6 @@ bool LcdMenu::process(const unsigned char c) {
     }
     renderer.restartTimer();
     bool handled = screen->process(this, c);
-
-    if (handled) {
-        FrameLifecycleRenderer* frame = frameLifecycle(renderer);
-        if (frame != NULL) {
-            frame->endFrame();
-        }
-    }
-
     return handled;
 };
 
@@ -63,11 +50,6 @@ void LcdMenu::show() {
     enabled = true;
     renderer.display->clear();
     screen->draw(&renderer);
-
-    FrameLifecycleRenderer* frame = frameLifecycle(renderer);
-    if (frame != NULL) {
-        frame->endFrame();
-    }
 }
 
 uint8_t LcdMenu::getCursor() {
@@ -90,18 +72,19 @@ void LcdMenu::refresh() {
         return;
     }
     screen->draw(&renderer);
-
-    FrameLifecycleRenderer* frame = frameLifecycle(renderer);
-    if (frame != NULL) {
-        frame->endFrame();
-    }
 }
 
 void LcdMenu::poll(uint16_t pollInterval) {
     if (!enabled || pollInterval == 0) {
         return;
     }
-    screen->poll(&renderer, pollInterval < 100 ? 100 : pollInterval);
+    bool redrawn = screen->poll(&renderer, pollInterval < 100 ? 100 : pollInterval);
+    if (redrawn) {
+        FrameLifecycleRenderer* frame = frameLifecycle(renderer);
+        if (frame != NULL) {
+            frame->endFrame();
+        }
+    }
 }
 bool LcdMenu::isEnabled() const {
     return enabled;

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -84,6 +84,16 @@ class MenuItem {
     // Destructor
     virtual ~MenuItem() noexcept = default;
 
+    /**
+     * @brief Optional capability lookup for item-specific extensions.
+     *
+     * Returns NULL when capability is not supported.
+     */
+    virtual const void* queryCapability(uint8_t capabilityId) const {
+        (void)capabilityId;
+        return NULL;
+    }
+
   protected:
     /**
      * @brief The number of available columns for the potential value of the item.

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -1,4 +1,14 @@
 #include "MenuScreen.h"
+#include "renderer/FrameLifecycleRenderer.h"
+
+namespace {
+FrameLifecycleRenderer* toFrameLifecycle(MenuRenderer* renderer) {
+    if (renderer == NULL) {
+        return NULL;
+    }
+    return static_cast<FrameLifecycleRenderer*>(renderer->queryExtension(FrameLifecycleRenderer::extensionId()));
+}
+}  // namespace
 
 void MenuScreen::setParent(MenuScreen* parent) {
     this->parent = parent;
@@ -52,6 +62,11 @@ void MenuScreen::setCursor(MenuRenderer* renderer, uint8_t position) {
 }
 
 void MenuScreen::draw(MenuRenderer* renderer) {
+    FrameLifecycleRenderer* frameLifecycle = toFrameLifecycle(renderer);
+    if (frameLifecycle != NULL) {
+        frameLifecycle->beginFrame();
+    }
+
     for (uint8_t i = 0; i < renderer->maxRows && i < items.size(); i++) {
         MenuItem* item = this->items[view + i];
         if (item == nullptr) {

--- a/src/MenuScreen.cpp
+++ b/src/MenuScreen.cpp
@@ -75,6 +75,10 @@ void MenuScreen::draw(MenuRenderer* renderer) {
         syncIndicators(i, renderer);
         item->draw(renderer);
     }
+
+    if (frameLifecycle != NULL) {
+        frameLifecycle->endFrame();
+    }
 }
 
 void MenuScreen::syncIndicators(uint8_t index, MenuRenderer* renderer) {
@@ -191,15 +195,21 @@ void MenuScreen::clear() {
     items.clear();
 }
 
-void MenuScreen::poll(MenuRenderer* renderer, uint16_t pollInterval) {
+bool MenuScreen::poll(MenuRenderer* renderer, uint16_t pollInterval) {
     static unsigned long lastPollTime = 0;
-    if (millis() - lastPollTime >= pollInterval) {
-        for (uint8_t i = 0; i < renderer->maxRows && (view + i) < items.size(); i++) {
-            MenuItem* item = this->items[view + i];
-            if (item == nullptr || !item->polling || MenuItem::isEditing()) continue;
-            syncIndicators(i, renderer);
-            item->draw(renderer);
-        }
-        lastPollTime = millis();
+    if (millis() - lastPollTime < pollInterval) {
+        return false;
     }
+
+    bool redrawn = false;
+    for (uint8_t i = 0; i < renderer->maxRows && (view + i) < items.size(); i++) {
+        MenuItem* item = this->items[view + i];
+        if (item == nullptr || !item->polling || MenuItem::isEditing()) continue;
+        syncIndicators(i, renderer);
+        item->draw(renderer);
+        redrawn = true;
+    }
+
+    lastPollTime = millis();
+    return redrawn;
 }

--- a/src/MenuScreen.h
+++ b/src/MenuScreen.h
@@ -156,8 +156,9 @@ class MenuScreen {
      * @brief Poll the screen for changes.
      * @param renderer The renderer to use for drawing.
      * @param pollInterval The interval to poll the screen.
+     * @return `true` when at least one polled item was redrawn.
      */
-    void poll(MenuRenderer* renderer, uint16_t pollInterval);
+    bool poll(MenuRenderer* renderer, uint16_t pollInterval);
 };
 
 #define MENU_SCREEN(screen, items, ...)           \

--- a/src/renderer/FrameLifecycleRenderer.h
+++ b/src/renderer/FrameLifecycleRenderer.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * @brief Optional renderer interface for buffered frame lifecycle.
+ *
+ * Renderers that require explicit begin/end frame hooks can expose this
+ * extension through MenuRenderer::queryExtension().
+ */
+class FrameLifecycleRenderer {
+  public:
+    static uint8_t extensionId() { return 1; }
+
+    virtual ~FrameLifecycleRenderer() {}
+
+    virtual void beginFrame() = 0;
+    virtual void endFrame() = 0;
+};

--- a/src/renderer/GraphicalMenuItem.h
+++ b/src/renderer/GraphicalMenuItem.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdint.h>
+
+class GraphicalDisplayInterface;
+
+/**
+ * @brief Optional capabilities for items rendered on graphical displays.
+ */
+class GraphicalMenuItem {
+  public:
+    static uint8_t capabilityId() { return 1; }
+
+    virtual ~GraphicalMenuItem() {}
+
+    virtual uint8_t measureGraphicalValueWidth(GraphicalDisplayInterface* display) const {
+        (void)display;
+        return 0;
+    }
+
+    virtual bool hasGraphicalToggle() const { return false; }
+
+    virtual bool graphicalToggleState() const { return false; }
+};

--- a/src/renderer/GraphicalRendererContext.h
+++ b/src/renderer/GraphicalRendererContext.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdint.h>
+
+class MenuItem;
+class GraphicalDisplayInterface;
+
+/**
+ * @brief Optional context API exposed by graphical renderers.
+ *
+ * This extension allows MenuScreen to share viewport and active-item context
+ * with renderer implementations that need richer layout information.
+ */
+class GraphicalRendererContext {
+  public:
+    static uint8_t extensionId() { return 2; }
+
+    virtual ~GraphicalRendererContext() {}
+
+    virtual void setViewportContext(uint8_t viewStart, uint8_t totalItems) = 0;
+    virtual void setValueAreaWidth(uint8_t width) = 0;
+    virtual void setActiveItem(const MenuItem* item) = 0;
+    virtual GraphicalDisplayInterface* getGraphicalDisplay() = 0;
+};

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -126,13 +126,31 @@ class MenuRenderer {
      * @brief Gets the maximum number of rows in the display.
      * @return Maximum number of rows.
      */
-    uint8_t getMaxRows() const;
+    virtual uint8_t getMaxRows() const;
 
     /**
      * @brief Gets the maximum number of columns in the display.
      * @return Maximum number of columns.
      */
-    uint8_t getMaxCols() const;
+    virtual uint8_t getMaxCols() const;
+
+    /**
+     * @brief Optional extension lookup for renderer-specific capabilities.
+     *
+     * Returns NULL when extension is not supported.
+     */
+    virtual void* queryExtension(uint8_t extensionId) {
+        (void)extensionId;
+        return NULL;
+    }
+
+    /**
+     * @brief Const overload for optional extension lookup.
+     */
+    virtual const void* queryExtension(uint8_t extensionId) const {
+        (void)extensionId;
+        return NULL;
+    }
 
     /**
      * @brief Calculates the available horizontal space for displaying content.

--- a/test/LcdMenu.cpp
+++ b/test/LcdMenu.cpp
@@ -8,6 +8,7 @@
 #include <ItemToggle.h>
 #include <MenuItem.h>
 #include <display/DisplayInterface.h>
+#include <renderer/FrameLifecycleRenderer.h>
 #include <renderer/MenuRenderer.h>
 
 #define LCD_ROWS 2
@@ -59,10 +60,11 @@ class TrackingDisplay : public DisplayInterface {
     void setBacklight(bool) override {}
 };
 
-class TrackingRenderer : public MenuRenderer {
+class TrackingRenderer : public MenuRenderer, public FrameLifecycleRenderer {
   public:
     TrackingDisplay display;
     bool itemDrawn = false;
+    uint8_t endFrameCalls = 0;
     TrackingRenderer() : MenuRenderer(&display, LCD_COLS, LCD_ROWS) {}
 
     void draw(uint8_t) override {}
@@ -70,6 +72,8 @@ class TrackingRenderer : public MenuRenderer {
     void clearBlinker() override {}
     void drawBlinker() override {}
     uint8_t getEffectiveCols() const override { return maxCols; }
+    void beginFrame() override {}
+    void endFrame() override { endFrameCalls++; }
 };
 
 // clang-format off
@@ -141,6 +145,28 @@ unittest(show_enables_and_draws_active_screen) {
     assertTrue(menu.isEnabled());
     assertTrue(renderer.display.cleared);
     assertTrue(renderer.itemDrawn);
+}
+
+unittest(refresh_flushes_renderer_frame) {
+    TrackingRenderer renderer;
+    LcdMenu menu(renderer);
+    menu.setScreen(mainScreen);
+
+    renderer.endFrameCalls = 0;
+    menu.refresh();
+
+    assertEqual((uint8_t)1, renderer.endFrameCalls);
+}
+
+unittest(process_flushes_renderer_when_command_handled) {
+    TrackingRenderer renderer;
+    LcdMenu menu(renderer);
+    menu.setScreen(mainScreen);
+    menu.setCursor(ITEM_TOGGLE_INDEX);
+
+    renderer.endFrameCalls = 0;
+    assertTrue(menu.process(ENTER));
+    assertEqual((uint8_t)1, renderer.endFrameCalls);
 }
 
 unittest(set_screen_skips_initial_label) {

--- a/test/LcdMenu.cpp
+++ b/test/LcdMenu.cpp
@@ -74,6 +74,20 @@ class TrackingRenderer : public MenuRenderer, public FrameLifecycleRenderer {
     uint8_t getEffectiveCols() const override { return maxCols; }
     void beginFrame() override {}
     void endFrame() override { endFrameCalls++; }
+
+    void* queryExtension(uint8_t extensionId) override {
+        if (extensionId == FrameLifecycleRenderer::extensionId()) {
+            return static_cast<FrameLifecycleRenderer*>(this);
+        }
+        return MenuRenderer::queryExtension(extensionId);
+    }
+
+    const void* queryExtension(uint8_t extensionId) const override {
+        if (extensionId == FrameLifecycleRenderer::extensionId()) {
+            return static_cast<const FrameLifecycleRenderer*>(this);
+        }
+        return MenuRenderer::queryExtension(extensionId);
+    }
 };
 
 // clang-format off

--- a/test/LcdMenu.cpp
+++ b/test/LcdMenu.cpp
@@ -64,6 +64,7 @@ class TrackingRenderer : public MenuRenderer, public FrameLifecycleRenderer {
   public:
     TrackingDisplay display;
     bool itemDrawn = false;
+    uint8_t beginFrameCalls = 0;
     uint8_t endFrameCalls = 0;
     TrackingRenderer() : MenuRenderer(&display, LCD_COLS, LCD_ROWS) {}
 
@@ -72,7 +73,7 @@ class TrackingRenderer : public MenuRenderer, public FrameLifecycleRenderer {
     void clearBlinker() override {}
     void drawBlinker() override {}
     uint8_t getEffectiveCols() const override { return maxCols; }
-    void beginFrame() override {}
+    void beginFrame() override { beginFrameCalls++; }
     void endFrame() override { endFrameCalls++; }
 
     void* queryExtension(uint8_t extensionId) override {
@@ -87,6 +88,20 @@ class TrackingRenderer : public MenuRenderer, public FrameLifecycleRenderer {
             return static_cast<const FrameLifecycleRenderer*>(this);
         }
         return MenuRenderer::queryExtension(extensionId);
+    }
+};
+
+class PollingMenuItem : public MenuItem {
+  public:
+    bool wasDrawn = false;
+
+    PollingMenuItem() : MenuItem("Polled") {
+        polling = true;
+    }
+
+    void draw(MenuRenderer* renderer) override {
+        wasDrawn = true;
+        renderer->drawItem(text, NULL);
     }
 };
 
@@ -166,20 +181,43 @@ unittest(refresh_flushes_renderer_frame) {
     LcdMenu menu(renderer);
     menu.setScreen(mainScreen);
 
+    renderer.beginFrameCalls = 0;
     renderer.endFrameCalls = 0;
     menu.refresh();
 
+    assertEqual((uint8_t)1, renderer.beginFrameCalls);
     assertEqual((uint8_t)1, renderer.endFrameCalls);
 }
 
-unittest(process_flushes_renderer_when_command_handled) {
+unittest(process_flushes_renderer_when_screen_redraws) {
     TrackingRenderer renderer;
     LcdMenu menu(renderer);
     menu.setScreen(mainScreen);
-    menu.setCursor(ITEM_TOGGLE_INDEX);
 
+    renderer.beginFrameCalls = 0;
     renderer.endFrameCalls = 0;
-    assertTrue(menu.process(ENTER));
+
+    assertTrue(menu.process(DOWN));
+    assertEqual((uint8_t)1, renderer.beginFrameCalls);
+    assertEqual((uint8_t)1, renderer.endFrameCalls);
+}
+
+unittest(poll_flushes_renderer_when_polled_item_redraws) {
+    TrackingRenderer renderer;
+    LcdMenu menu(renderer);
+    PollingMenuItem polledItem;
+    std::vector<MenuItem*> items = {&polledItem};
+    MenuScreen screen(items);
+
+    menu.setScreen(&screen);
+
+    polledItem.wasDrawn = false;
+    renderer.endFrameCalls = 0;
+
+    delay(120);
+    menu.poll(100);
+
+    assertTrue(polledItem.wasDrawn);
     assertEqual((uint8_t)1, renderer.endFrameCalls);
 }
 

--- a/test/LcdMenu.cpp
+++ b/test/LcdMenu.cpp
@@ -1,4 +1,5 @@
 #define protected public
+#include "Godmode.h"
 #include <ItemInput.h>
 #include <MenuScreen.h>
 #undef protected
@@ -189,17 +190,29 @@ unittest(refresh_flushes_renderer_frame) {
     assertEqual((uint8_t)1, renderer.endFrameCalls);
 }
 
-unittest(process_flushes_renderer_when_screen_redraws) {
+unittest(process_flushes_renderer_when_back_navigates_and_redraws) {
     TrackingRenderer renderer;
     LcdMenu menu(renderer);
-    menu.setScreen(mainScreen);
+    MenuItem* parentItem = ITEM_BASIC("Parent");
+    MenuItem* childItem = ITEM_BASIC("Child");
+    std::vector<MenuItem*> parentItems = {parentItem};
+    std::vector<MenuItem*> childItems = {childItem};
+    MenuScreen parent(parentItems);
+    MenuScreen child(childItems);
+    child.setParent(&parent);
+    menu.setScreen(&child);
+
+    MenuItem::endEdit();
 
     renderer.beginFrameCalls = 0;
     renderer.endFrameCalls = 0;
 
-    assertTrue(menu.process(DOWN));
+    assertTrue(menu.process(BACK));
     assertEqual((uint8_t)1, renderer.beginFrameCalls);
     assertEqual((uint8_t)1, renderer.endFrameCalls);
+
+    delete parentItem;
+    delete childItem;
 }
 
 unittest(poll_flushes_renderer_when_polled_item_redraws) {
@@ -211,10 +224,11 @@ unittest(poll_flushes_renderer_when_polled_item_redraws) {
 
     menu.setScreen(&screen);
 
+    MenuItem::endEdit();
+    GODMODE()->micros += 200000;
+
     polledItem.wasDrawn = false;
     renderer.endFrameCalls = 0;
-
-    delay(120);
     menu.poll(100);
 
     assertTrue(polledItem.wasDrawn);


### PR DESCRIPTION
## Summary
- Add RTTI-free extension hooks to core renderer/item APIs via `MenuRenderer::queryExtension()` and `MenuItem::queryCapability()`.
- Introduce optional extension interfaces for frame lifecycle and graphical context/capabilities (`FrameLifecycleRenderer`, `GraphicalRendererContext`, `GraphicalMenuItem`) without adding pixel-specific methods to base classes.
- Wire frame lifecycle hooks into menu flow: `MenuScreen::draw()` calls `beginFrame()` and `LcdMenu` now calls `endFrame()` after handled draw-triggering actions (`setScreen`, `show`, `refresh`, handled `process`).
- Add unit tests verifying frame flush behavior on `refresh()` and handled `process()` commands.
- Document the extension model in rendering docs.

## Verification
- Attempted to run Arduino unit tests locally (`bundle exec arduino_ci.rb --skip-examples-compilation`), but local Ruby gem install requires privileged system paths on this machine.
- Performed static diff review and kept PR scope to extension-core + unit tests + docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced an extension mechanism allowing renderers to expose optional capabilities and frame lifecycle hooks.
  * Added support for menu items to discover and expose renderer-compatible capabilities.
  * Enabled specialized renderers to participate in frame lifecycle management for optimized buffered drawing.

* **Documentation**
  * Added documentation defining the extension mechanism and capability query approach for advanced renderers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->