### PR TITLE
feat: add graphical capabilities to core items and widgets

### DIFF
--- a/docs/source/overview/rendering/graphical-display.rst
+++ b/docs/source/overview/rendering/graphical-display.rst
@@ -24,6 +24,22 @@ Menu integration
 through ``GraphicalRendererContext``. This lets the renderer recompute visible
 rows and value-column widths when fonts differ per item.
 
+Item capabilities
+-----------------
+
+Built-in items now expose graphical capabilities through
+``GraphicalMenuItem`` without RTTI:
+
+- ``ITEM_BASIC`` and ``ITEM_LABEL`` opt into graphical-item capabilities.
+- ``ITEM_BOOL`` and ``ITEM_TOGGLE`` expose toggle state for checkbox drawing.
+- Widget-based items (for example ``ITEM_LIST`` and ``ITEM_RANGE``) expose
+  list-indicator support.
+- ``ITEM_VALUE`` reports the rendered value width for right-aligned layout.
+
+Renderer-specific enhancements remain optional through ``queryExtension()``.
+For example, indicators use ``GraphicalIndicatorRenderer`` and value selection
+highlighting can be added with ``GraphicalValueSelectionRenderer``.
+
 Basic usage
 -----------
 

--- a/src/BaseItemManyWidgets.h
+++ b/src/BaseItemManyWidgets.h
@@ -4,12 +4,16 @@
 
 #include "LcdMenu.h"
 #include "MenuItem.h"
+#include "display/GraphicalDisplayInterface.h"
+#include "renderer/GraphicalIndicatorRenderer.h"
+#include "renderer/GraphicalMenuItem.h"
+#include "renderer/GraphicalValueSelectionRenderer.h"
 #include "utils/lcd_menu_utils.h"
 #include "utils/std.h"
 #include "widget/BaseWidget.h"
 #include <vector>
 
-class BaseItemManyWidgets : public MenuItem {
+class BaseItemManyWidgets : public MenuItem, public GraphicalMenuItem {
   protected:
     std::vector<BaseWidget*> widgets;
     uint8_t activeWidget = 0;
@@ -71,6 +75,38 @@ class BaseItemManyWidgets : public MenuItem {
         }
     }
 
+    uint8_t measureGraphicalValueWidth(GraphicalDisplayInterface* display) const override {
+        if (display == NULL) {
+            return 0;
+        }
+
+        char buf[ITEM_DRAW_BUFFER_SIZE];
+        uint8_t index = 0;
+        for (size_t i = 0; i < widgets.size() && index < ITEM_DRAW_BUFFER_SIZE - 1; i++) {
+            uint8_t written = widgets[i]->draw(buf, index);
+            uint8_t maxWritable = static_cast<uint8_t>(ITEM_DRAW_BUFFER_SIZE - 1 - index);
+            index += written > maxWritable ? maxWritable : written;
+        }
+        buf[index] = '\0';
+        return display->getTextWidth(buf);
+    }
+
+    bool hasGraphicalListIndicator() const override {
+        for (size_t i = 0; i < widgets.size(); i++) {
+            if (widgets[i] != NULL && widgets[i]->isList()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    const void* queryCapability(uint8_t capabilityId) const override {
+        if (capabilityId == GraphicalMenuItem::capabilityId()) {
+            return static_cast<const GraphicalMenuItem*>(this);
+        }
+        return MenuItem::queryCapability(capabilityId);
+    }
+
     virtual ~BaseItemManyWidgets() {
         for (auto widget : widgets) {
             delete widget;
@@ -111,21 +147,67 @@ class BaseItemManyWidgets : public MenuItem {
 
         uint8_t index = 0;
         uint8_t cursorCol = 0;
+        bool hasListWidget = false;
+        uint8_t activeSegmentStart = 0;
+        uint8_t activeSegmentLength = 0;
+
+        GraphicalValueSelectionRenderer* valueSelectionRenderer =
+            static_cast<GraphicalValueSelectionRenderer*>(renderer->queryExtension(GraphicalValueSelectionRenderer::extensionId()));
 
         for (uint8_t i = 0; i < widgets.size(); i++) {
-            index += widgets[i]->draw(buf, index);
+            uint8_t widgetStart = index;
+            uint8_t written = widgets[i]->draw(buf, index);
+            uint8_t maxWritable = index < ITEM_DRAW_BUFFER_SIZE - 1 ? static_cast<uint8_t>(ITEM_DRAW_BUFFER_SIZE - 1 - index) : 0;
+            index += written > maxWritable ? maxWritable : written;
+            hasListWidget = hasListWidget || widgets[i]->isList();
             if (i == activeWidget && MenuItem::isEditing()) {
-                // Calculate the available space for the widgets after the text
-                size_t v_size = renderer->getEffectiveCols() - strlen(text) - 1;
-                // Adjust the view shift to ensure the active widget is visible
-                renderer->viewShift = index > v_size ? index - v_size : 0;
+                activeSegmentStart = widgetStart;
+                activeSegmentLength = index > widgetStart ? static_cast<uint8_t>(index - widgetStart) : 0;
+
+                const char* label = text == NULL ? "" : text;
+                int16_t valueArea = static_cast<int16_t>(renderer->getEffectiveCols()) - static_cast<int16_t>(strlen(label)) - 1;
+                int16_t shift = static_cast<int16_t>(index) - valueArea;
+                renderer->viewShift = shift > 0 ? static_cast<uint8_t>(shift) : 0;
+
+                if (valueSelectionRenderer != NULL) {
+                    if (activeSegmentLength > 0) {
+                        valueSelectionRenderer->setValueSelection(activeSegmentStart, activeSegmentLength);
+                    } else {
+                        valueSelectionRenderer->clearValueSelection();
+                    }
+                }
+
                 // Draw the item with the renderer, indicating if it's the last widget
                 renderer->drawItem(text, buf, i == widgets.size() - 1);
                 // Calculate the cursor column position for the active widget
-                cursorCol = renderer->getCursorCol() - 1 - widgets[i]->cursorOffset;
+                uint8_t endCol = renderer->getCursorCol();
+                uint8_t offset = static_cast<uint8_t>(1 + widgets[i]->cursorOffset);
+                cursorCol = endCol > offset ? endCol - offset : 0;
             }
         }
+        buf[index < ITEM_DRAW_BUFFER_SIZE ? index : ITEM_DRAW_BUFFER_SIZE - 1] = '\0';
+
+        if (valueSelectionRenderer != NULL) {
+            if (MenuItem::isEditing() && activeSegmentLength > 0) {
+                valueSelectionRenderer->setValueSelection(activeSegmentStart, activeSegmentLength);
+            } else {
+                valueSelectionRenderer->clearValueSelection();
+            }
+        }
+
         renderer->drawItem(text, buf);
+
+        if (valueSelectionRenderer != NULL) {
+            valueSelectionRenderer->clearValueSelection();
+        }
+
+        if (hasListWidget) {
+            GraphicalIndicatorRenderer* indicatorRenderer =
+                static_cast<GraphicalIndicatorRenderer*>(renderer->queryExtension(GraphicalIndicatorRenderer::extensionId()));
+            if (indicatorRenderer != NULL) {
+                indicatorRenderer->drawListIndicator();
+            }
+        }
 
         if (MenuItem::isEditing()) {
             renderer->moveCursor(cursorCol, renderer->getCursorRow());

--- a/src/BaseItemZeroWidget.h
+++ b/src/BaseItemZeroWidget.h
@@ -3,6 +3,7 @@
 #define BASE_ITEM_ZERO_WIDGET_H
 
 #include "MenuItem.h"
+#include "renderer/GraphicalMenuItem.h"
 
 /**
  * @class BaseItemZeroWidget
@@ -15,7 +16,7 @@
  * @note This class is intended to be used as a base class for other menu items.
  *       It should not be instantiated directly.
  */
-class BaseItemZeroWidget : public MenuItem {
+class BaseItemZeroWidget : public MenuItem, public GraphicalMenuItem {
   public:
     virtual ~BaseItemZeroWidget() = default;
     /**
@@ -24,6 +25,13 @@ class BaseItemZeroWidget : public MenuItem {
      * @param text The text to display for the menu item.
      */
     explicit BaseItemZeroWidget(const char* text) : MenuItem(text) {}
+
+    const void* queryCapability(uint8_t capabilityId) const override {
+        if (capabilityId == GraphicalMenuItem::capabilityId()) {
+            return static_cast<const GraphicalMenuItem*>(this);
+        }
+        return MenuItem::queryCapability(capabilityId);
+    }
 
   protected:
     virtual void handleCommit(LcdMenu* menu) = 0;

--- a/src/ItemBool.h
+++ b/src/ItemBool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ItemWidget.h>
+#include <display/GraphicalDisplayInterface.h>
 #include <widget/WidgetBool.h>
 
 /**
@@ -15,6 +16,10 @@
  */
 template <typename V = bool>
 class ItemBool : public ItemWidget<V> {
+  private:
+    const char* textOn = NULL;
+    const char* textOff = NULL;
+
   public:
     virtual ~ItemBool() = default;
 
@@ -26,7 +31,40 @@ class ItemBool : public ItemWidget<V> {
         const char* format,
         const uint8_t cursorOffset,
         typename ItemWidget<V>::CallbackType callback)
-        : ItemWidget<V>(text, new WidgetBool<V>(value, textOn, textOff, format, cursorOffset), callback) {}
+        : ItemWidget<V>(text, new WidgetBool<V>(value, textOn, textOff, format, cursorOffset), callback),
+          textOn(textOn),
+          textOff(textOff) {}
+
+    uint8_t measureGraphicalValueWidth(GraphicalDisplayInterface* display) const override {
+        if (display == NULL) {
+            return 0;
+        }
+        uint8_t toggleWidth = display->getFontHeight();
+        if (toggleWidth > 4) {
+            toggleWidth -= 4;
+        }
+
+        if (toggleWidth < 3) {
+            toggleWidth = 3;
+        }
+
+        uint8_t onWidth = display->getTextWidth(textOn == NULL ? "" : textOn);
+        uint8_t offWidth = display->getTextWidth(textOff == NULL ? "" : textOff);
+        uint8_t textWidth = onWidth > offWidth ? onWidth : offWidth;
+
+        return toggleWidth > textWidth ? toggleWidth : textWidth;
+    }
+
+    bool hasGraphicalToggle() const override { return true; }
+
+    bool graphicalToggleState() const override {
+        BaseWidget* widget = this->getWidgetAt(0);
+        if (widget == nullptr) {
+            return false;
+        }
+        BaseWidgetValue<V>* boolWidget = static_cast<BaseWidgetValue<V>*>(widget);
+        return static_cast<bool>(boolWidget->getValue());
+    }
 };
 
 /**

--- a/src/ItemLabel.h
+++ b/src/ItemLabel.h
@@ -6,9 +6,9 @@
  * @class ItemLabel
  * @brief An unselectable menu item used for titles or separators.
  */
-class ItemLabel final : public MenuItem {
+class ItemLabel final : public BasicItem {
   public:
-    explicit ItemLabel(const char* text) : MenuItem(text) {}
+    explicit ItemLabel(const char* text) : BasicItem(text) {}
 
     bool isSelectable() const override { return false; }
 };

--- a/src/ItemSubMenu.h
+++ b/src/ItemSubMenu.h
@@ -3,6 +3,7 @@
 #include "BaseItemZeroWidget.h"
 #include "LcdMenu.h"
 #include "MenuScreen.h"
+#include "renderer/GraphicalIndicatorRenderer.h"
 
 /**
  * @class ItemSubMenu
@@ -34,6 +35,15 @@ class ItemSubMenu : public BaseItemZeroWidget {
     }
 
   protected:
+    void draw(MenuRenderer* renderer) override {
+        renderer->drawItem(text, nullptr);
+        GraphicalIndicatorRenderer* indicatorRenderer =
+            static_cast<GraphicalIndicatorRenderer*>(renderer->queryExtension(GraphicalIndicatorRenderer::extensionId()));
+        if (indicatorRenderer != NULL) {
+            indicatorRenderer->drawSubMenuIndicator();
+        }
+    }
+
     void handleCommit(LcdMenu* menu) override {
         LOG(F("ItemSubMenu::changeScreen"), text);
         screen->setParent(menu->getScreen());

--- a/src/ItemToggle.h
+++ b/src/ItemToggle.h
@@ -3,6 +3,8 @@
 
 #include "LcdMenu.h"
 #include "MenuItem.h"
+#include "display/GraphicalDisplayInterface.h"
+#include "renderer/GraphicalMenuItem.h"
 #include <utils/lcd_menu_utils.h>
 
 /**
@@ -16,7 +18,7 @@
  *
  * Additionally to `text` this item has ON/OFF `enabled` state.
  */
-class ItemToggle : public MenuItem {
+class ItemToggle : public MenuItem, public GraphicalMenuItem {
   private:
     bool enabled = false;
     const char* textOn = NULL;
@@ -81,6 +83,34 @@ class ItemToggle : public MenuItem {
     const char* getTextOn() { return this->textOn; }
 
     const char* getTextOff() { return this->textOff; }
+
+    uint8_t measureGraphicalValueWidth(GraphicalDisplayInterface* display) const override {
+        if (display == NULL) {
+            return 0;
+        }
+        uint8_t toggleWidth = display->getFontHeight();
+        if (toggleWidth > 4) {
+            toggleWidth -= 4;
+        }
+        if (toggleWidth < 3) {
+            toggleWidth = 3;
+        }
+        uint8_t onWidth = display->getTextWidth(textOn == NULL ? "" : textOn);
+        uint8_t offWidth = display->getTextWidth(textOff == NULL ? "" : textOff);
+        uint8_t textWidth = onWidth > offWidth ? onWidth : offWidth;
+        return toggleWidth > textWidth ? toggleWidth : textWidth;
+    }
+
+    bool hasGraphicalToggle() const override { return true; }
+
+    bool graphicalToggleState() const override { return enabled; }
+
+    const void* queryCapability(uint8_t capabilityId) const override {
+        if (capabilityId == GraphicalMenuItem::capabilityId()) {
+            return static_cast<const GraphicalMenuItem*>(this);
+        }
+        return MenuItem::queryCapability(capabilityId);
+    }
 
     void draw(MenuRenderer* renderer) override {
         renderer->drawItem(text, enabled ? textOn : textOff);

--- a/src/ItemValue.h
+++ b/src/ItemValue.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "display/GraphicalDisplayInterface.h"
 #include "utils/custom_printf.h"
 
 #include "BaseItemZeroWidget.h"
@@ -30,6 +31,15 @@ class ItemValue : public BaseItemZeroWidget {
         char buffer[ITEM_DRAW_BUFFER_SIZE];
         snprintf(buffer, ITEM_DRAW_BUFFER_SIZE, format, value);
         renderer->drawItem(text, buffer);
+    }
+
+    uint8_t measureGraphicalValueWidth(GraphicalDisplayInterface* display) const override {
+        if (display == NULL) {
+            return 0;
+        }
+        char buffer[ITEM_DRAW_BUFFER_SIZE];
+        snprintf(buffer, ITEM_DRAW_BUFFER_SIZE, format, value);
+        return display->getTextWidth(buffer);
     }
 };
 

--- a/src/MenuItem.h
+++ b/src/MenuItem.h
@@ -27,8 +27,9 @@
 #ifndef MenuItem_H
 #define MenuItem_H
 
-#define ITEM_DRAW_BUFFER_SIZE 25
+#define ITEM_DRAW_BUFFER_SIZE 64
 
+#include "renderer/GraphicalMenuItem.h"
 #include "renderer/MenuRenderer.h"
 #include "utils/lcd_menu_constants.h"
 #include <utils/lcd_menu_utils.h>
@@ -109,7 +110,9 @@ class MenuItem {
      * Effectively const, but initialized lately when renderer is injected.
      */
     inline uint8_t getViewSize(MenuRenderer* renderer) const {
-        return renderer->getEffectiveCols() - strlen(text) - 1 + renderer->viewShift;
+        const char* label = text == NULL ? "" : text;
+        int16_t viewSize = static_cast<int16_t>(renderer->getEffectiveCols()) - static_cast<int16_t>(strlen(label)) - 1 + renderer->viewShift;
+        return viewSize > 0 ? static_cast<uint8_t>(viewSize) : 0;
     };
     /**
      * @brief Process a command decoded in 1 byte.
@@ -134,6 +137,18 @@ class MenuItem {
     };
 };
 
-#define ITEM_BASIC(...) (new MenuItem(__VA_ARGS__))
+class BasicItem : public MenuItem, public GraphicalMenuItem {
+  public:
+    explicit BasicItem(const char* text) : MenuItem(text) {}
+
+    const void* queryCapability(uint8_t capabilityId) const override {
+        if (capabilityId == GraphicalMenuItem::capabilityId()) {
+            return static_cast<const GraphicalMenuItem*>(this);
+        }
+        return MenuItem::queryCapability(capabilityId);
+    }
+};
+
+#define ITEM_BASIC(...) (new BasicItem(__VA_ARGS__))
 
 #endif

--- a/src/renderer/GraphicalValueSelectionRenderer.h
+++ b/src/renderer/GraphicalValueSelectionRenderer.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * @brief Optional renderer interface for highlighting a value substring.
+ */
+class GraphicalValueSelectionRenderer {
+  public:
+    static uint8_t extensionId() { return 4; }
+
+    virtual ~GraphicalValueSelectionRenderer() {}
+
+    virtual void setValueSelection(uint8_t start, uint8_t length) = 0;
+    virtual void clearValueSelection() = 0;
+};

--- a/src/widget/BaseWidget.h
+++ b/src/widget/BaseWidget.h
@@ -47,6 +47,8 @@ class BaseWidget {
      */
     virtual uint8_t draw(char* buffer, const uint8_t start = 0) = 0;
 
+    virtual bool isList() const { return false; }
+
     virtual void startEdit() {}
 
     virtual void cancelEdit() {}

--- a/src/widget/WidgetBool.h
+++ b/src/widget/WidgetBool.h
@@ -34,7 +34,14 @@ class WidgetBool : public BaseWidgetValue<V> {
   protected:
     uint8_t draw(char* buffer, const uint8_t start) override {
         if (start >= ITEM_DRAW_BUFFER_SIZE) return 0;
-        return snprintf(buffer + start, ITEM_DRAW_BUFFER_SIZE - start, this->format, static_cast<bool>(this->value) ? textOn : textOff);
+
+        const char* selectedText = static_cast<bool>(this->value) ? textOn : textOff;
+        if (selectedText == NULL) {
+            selectedText = "";
+        }
+
+        const char* format = this->format == NULL ? "%s" : this->format;
+        return snprintf(buffer + start, ITEM_DRAW_BUFFER_SIZE - start, format, selectedText);
     }
     /**
      * @brief Process command.

--- a/src/widget/WidgetList.h
+++ b/src/widget/WidgetList.h
@@ -61,6 +61,9 @@ class WidgetList : public BaseWidgetValue<V> {
                 return false;
         }
     }
+
+    bool isList() const override { return true; }
+
     void updateValue(const __FlashStringHelper* action) {
         BaseWidgetValue<V>::handleChange();
         LOG(action, (uint8_t)this->value);

--- a/src/widget/WidgetRange.h
+++ b/src/widget/WidgetRange.h
@@ -108,6 +108,8 @@ class WidgetRange : public BaseWidgetValue<V> {
         return snprintf(buffer + start, ITEM_DRAW_BUFFER_SIZE - start, this->format, static_cast<T>(this->value));
     }
 
+    bool isList() const override { return true; }
+
     void startEdit() override { originalValue = static_cast<T>(this->value); }
 
     void cancelEdit() override { this->value = originalValue; }

--- a/test/ItemValue.cpp
+++ b/test/ItemValue.cpp
@@ -128,16 +128,21 @@ unittest(value_and_widget_items_measure_graphical_width) {
 
     int value = 123;
     ItemValue<int> valueItem("Count", value, "%d");
-    assertEqual((uint8_t)(3 * GraphicalMeasureDisplay::kCharWidth), valueItem.measureGraphicalValueWidth(&display));
+    const GraphicalMenuItem* valueCapability = static_cast<const GraphicalMenuItem*>(valueItem.queryCapability(GraphicalMenuItem::capabilityId()));
+    assertTrue(valueCapability != NULL);
+    assertEqual((uint8_t)(3 * GraphicalMeasureDisplay::kCharWidth), valueCapability->measureGraphicalValueWidth(&display));
 
     ItemBool<bool> boolItem("Enabled", false, "YES", "NO", "%s", 0, nullptr);
-    assertEqual((uint8_t)(3 * GraphicalMeasureDisplay::kCharWidth), boolItem.measureGraphicalValueWidth(&display));
+    const GraphicalMenuItem* boolCapability = static_cast<const GraphicalMenuItem*>(boolItem.queryCapability(GraphicalMenuItem::capabilityId()));
+    assertTrue(boolCapability != NULL);
+    assertEqual((uint8_t)(3 * GraphicalMeasureDisplay::kCharWidth), boolCapability->measureGraphicalValueWidth(&display));
 }
 
 unittest(list_and_range_items_report_graphical_list_indicator) {
     std::vector<const char*> values = {"A", "B", "C"};
     ItemList<const char*, uint8_t>* listItem = ITEM_LIST("Mode", values, nullptr);
-    ItemRange<int, int>* rangeItem = ITEM_RANGE("Speed", 3, 1, 0, 9, nullptr, "%d");
+    void (*rangeCallback)(const int) = nullptr;
+    ItemRange<int, int>* rangeItem = ITEM_RANGE("Speed", 3, 1, 0, 9, rangeCallback, "%d");
 
     const GraphicalMenuItem* listCapability = static_cast<const GraphicalMenuItem*>(listItem->queryCapability(GraphicalMenuItem::capabilityId()));
     const GraphicalMenuItem* rangeCapability = static_cast<const GraphicalMenuItem*>(rangeItem->queryCapability(GraphicalMenuItem::capabilityId()));

--- a/test/ItemValue.cpp
+++ b/test/ItemValue.cpp
@@ -1,10 +1,18 @@
 #include "Godmode.h"
 #include <ArduinoUnitTests.h>
+#include <ItemBool.h>
+#include <ItemLabel.h>
+#include <ItemList.h>
+#include <ItemRange.h>
+#include <ItemToggle.h>
 #include <ItemValue.h>
 #include <LcdMenu.h>
 #include <MenuScreen.h>
 #include <display/DisplayInterface.h>
+#include <display/GraphicalDisplayInterface.h>
+#include <renderer/GraphicalMenuItem.h>
 #include <renderer/MenuRenderer.h>
+#include <string.h>
 
 #define LCD_ROWS 1
 #define LCD_COLS 16
@@ -40,6 +48,33 @@ class CaptureRenderer : public MenuRenderer {
     uint8_t getEffectiveCols() const override { return maxCols; }
 };
 
+class GraphicalMeasureDisplay : public GraphicalDisplayInterface {
+  public:
+    static const uint8_t kCharWidth = 6;
+    void begin() override {}
+    void clear() override {}
+    void show() override {}
+    void hide() override {}
+    void draw(uint8_t) override {}
+    void draw(const char*) override {}
+    void setCursor(uint8_t, uint8_t) override {}
+    void setBacklight(bool) override {}
+    void setFont(const uint8_t*) override {}
+    uint8_t getDisplayWidth() const override { return 128; }
+    uint8_t getDisplayHeight() const override { return 64; }
+    uint8_t getFontWidth() const override { return kCharWidth; }
+    uint8_t getFontHeight() const override { return 8; }
+    uint8_t getTextWidth(const char* text) override {
+        return text == NULL ? 0 : static_cast<uint8_t>(strlen(text) * kCharWidth);
+    }
+    void setDrawColor(uint8_t) override {}
+    void clearBuffer() override {}
+    void sendBuffer() override {}
+    void drawBox(uint8_t, uint8_t, uint8_t, uint8_t) override {}
+    void drawFrame(uint8_t, uint8_t, uint8_t, uint8_t) override {}
+    void drawXbm(uint8_t, uint8_t, uint8_t, uint8_t, const uint8_t*) override {}
+};
+
 // clang-format off
 float tracked = 0.0;
 MENU_SCREEN(mainScreen, mainItems, ITEM_VALUE("Temp", tracked, "%.1f"));
@@ -58,6 +93,62 @@ unittest(item_value_updates_after_poll) {
     GODMODE()->micros += 200000;  // advance time
     menu.poll(100);
     assertEqual("42.5", renderer.lastValue.c_str());
+}
+
+unittest(basic_and_label_expose_graphical_capability) {
+    MenuItem* basic = ITEM_BASIC("Basic");
+    ItemLabel* label = ITEM_LABEL("Label");
+
+    assertTrue(basic->queryCapability(GraphicalMenuItem::capabilityId()) != NULL);
+    assertTrue(label->queryCapability(GraphicalMenuItem::capabilityId()) != NULL);
+
+    delete basic;
+    delete label;
+}
+
+unittest(toggle_and_bool_report_graphical_toggle_state) {
+    ItemToggle toggle("Power", "ON", "OFF", nullptr);
+    const GraphicalMenuItem* toggleCapability = static_cast<const GraphicalMenuItem*>(toggle.queryCapability(GraphicalMenuItem::capabilityId()));
+    assertTrue(toggleCapability != NULL);
+    assertTrue(toggleCapability->hasGraphicalToggle());
+    assertFalse(toggleCapability->graphicalToggleState());
+
+    toggle.setIsOn(true);
+    assertTrue(toggleCapability->graphicalToggleState());
+
+    ItemBool<bool> boolItem("Enabled", true, "YES", "NO", "%s", 0, nullptr);
+    const GraphicalMenuItem* boolCapability = static_cast<const GraphicalMenuItem*>(boolItem.queryCapability(GraphicalMenuItem::capabilityId()));
+    assertTrue(boolCapability != NULL);
+    assertTrue(boolCapability->hasGraphicalToggle());
+    assertTrue(boolCapability->graphicalToggleState());
+}
+
+unittest(value_and_widget_items_measure_graphical_width) {
+    GraphicalMeasureDisplay display;
+
+    int value = 123;
+    ItemValue<int> valueItem("Count", value, "%d");
+    assertEqual((uint8_t)(3 * GraphicalMeasureDisplay::kCharWidth), valueItem.measureGraphicalValueWidth(&display));
+
+    ItemBool<bool> boolItem("Enabled", false, "YES", "NO", "%s", 0, nullptr);
+    assertEqual((uint8_t)(3 * GraphicalMeasureDisplay::kCharWidth), boolItem.measureGraphicalValueWidth(&display));
+}
+
+unittest(list_and_range_items_report_graphical_list_indicator) {
+    std::vector<const char*> values = {"A", "B", "C"};
+    ItemList<const char*, uint8_t>* listItem = ITEM_LIST("Mode", values, nullptr);
+    ItemRange<int, int>* rangeItem = ITEM_RANGE("Speed", 3, 1, 0, 9, nullptr, "%d");
+
+    const GraphicalMenuItem* listCapability = static_cast<const GraphicalMenuItem*>(listItem->queryCapability(GraphicalMenuItem::capabilityId()));
+    const GraphicalMenuItem* rangeCapability = static_cast<const GraphicalMenuItem*>(rangeItem->queryCapability(GraphicalMenuItem::capabilityId()));
+
+    assertTrue(listCapability != NULL);
+    assertTrue(rangeCapability != NULL);
+    assertTrue(listCapability->hasGraphicalListIndicator());
+    assertTrue(rangeCapability->hasGraphicalListIndicator());
+
+    delete listItem;
+    delete rangeItem;
 }
 
 unittest_main()


### PR DESCRIPTION
## Summary
- Add `GraphicalMenuItem` capability support across core items and widget-backed items, including graphical value-width measurement, toggle/list indicators, and a `BasicItem` implementation for `ITEM_BASIC`/`ITEM_LABEL`.
- Improve widget/item drawing safety for graphical rendering by hardening buffer handling (`ITEM_DRAW_BUFFER_SIZE` growth, null-safe bool widget formatting) and exposing optional `GraphicalValueSelectionRenderer` extension hooks.
- Add unit coverage for new item capabilities in `test/ItemValue.cpp` and document the new graphical item capability model in `docs/source/overview/rendering/graphical-display.rst`.