### PR TITLE
Refine graphical renderer parity

### DIFF
--- a/src/renderer/GraphicalDisplayRenderer.cpp
+++ b/src/renderer/GraphicalDisplayRenderer.cpp
@@ -49,11 +49,17 @@ GraphicalDisplayRenderer::GraphicalDisplayRenderer(
     : MenuRenderer(display, 0, 0),
       gDisplay(display),
       defaultFont(defaultFont),
-      cursorIcon(cursorIcon == NULL ? ">" : cursorIcon),
-      editCursorIcon(editCursorIcon == NULL ? "*" : editCursorIcon) {}
+      cursorIcon(cursorIcon),
+      editCursorIcon(editCursorIcon) {}
 
 void GraphicalDisplayRenderer::setDefaultFont(const uint8_t* font) {
     defaultFont = font;
+
+    if (defaultFont != NULL) {
+        gDisplay->setFont(defaultFont);
+    }
+    captureCurrentFontMetrics();
+
     applyItemFont(activeItem);
 }
 
@@ -61,6 +67,12 @@ bool GraphicalDisplayRenderer::setItemFont(MenuItem* item, const uint8_t* font) 
     if (!::setItemFont(item, font)) {
         return false;
     }
+
+    if (font != NULL) {
+        gDisplay->setFont(font);
+        captureCurrentFontMetrics();
+    }
+
     applyItemFont(activeItem);
     return true;
 }
@@ -98,9 +110,16 @@ void GraphicalDisplayRenderer::applyItemFont(const MenuItem* item) {
 
 void GraphicalDisplayRenderer::begin() {
     MenuRenderer::begin();
+
     maxRowHeight = 8;
     maxFontWidth = 1;
-    applyItemFont(NULL);
+
+    if (defaultFont != NULL) {
+        gDisplay->setFont(defaultFont);
+    }
+    captureCurrentFontMetrics();
+    applyItemFont(activeItem);
+
     beginFrame();
     endFrame();
 }
@@ -318,11 +337,14 @@ void GraphicalDisplayRenderer::drawSubMenuIndicator() {
     uint8_t contentRight = gDisplay->getDisplayWidth() > rightInset ? gDisplay->getDisplayWidth() - rightInset : gDisplay->getDisplayWidth();
     uint8_t x = contentRight > rightPadding + submenuGlyphWidth ? contentRight - rightPadding - submenuGlyphWidth : leftPadding;
     uint8_t y = top + (h > submenuGlyphHeight ? (h - submenuGlyphHeight) / 2 : 0);
+
+    gDisplay->setDrawColor(hasFocus && !MenuItem::isEditing() ? 0 : 1);
     gDisplay->drawBox(x, y, 1, 1);
     gDisplay->drawBox(x, y + 1, 2, 1);
     gDisplay->drawBox(x, y + 2, 3, 1);
     gDisplay->drawBox(x, y + 3, 2, 1);
     gDisplay->drawBox(x, y + 4, 1, 1);
+    gDisplay->setDrawColor(1);
 }
 
 void GraphicalDisplayRenderer::drawListIndicator() {
@@ -332,7 +354,10 @@ void GraphicalDisplayRenderer::drawListIndicator() {
     uint8_t contentRight = gDisplay->getDisplayWidth() > rightInset ? gDisplay->getDisplayWidth() - rightInset : gDisplay->getDisplayWidth();
     uint8_t x = contentRight > rightPadding + listGlyphWidth ? contentRight - rightPadding - listGlyphWidth : leftPadding;
     uint8_t y = top + (h > listGlyphHeight ? (h - listGlyphHeight) / 2 : 0);
+
+    gDisplay->setDrawColor(hasFocus && !MenuItem::isEditing() ? 0 : 1);
     gDisplay->drawXbm(x, y, listGlyphWidth, listGlyphHeight, listGlyph);
+    gDisplay->setDrawColor(1);
 }
 
 uint8_t GraphicalDisplayRenderer::measureText(const char* text) const {
@@ -348,7 +373,7 @@ uint8_t GraphicalDisplayRenderer::toggleIndicatorWidth() const {
 }
 
 uint8_t GraphicalDisplayRenderer::rowHeight() const {
-    return maxRowHeight == 0 ? 8 : maxRowHeight + 2;
+    return maxRowHeight == 0 ? 8 : maxRowHeight;
 }
 
 uint8_t GraphicalDisplayRenderer::getMaxRows() const {

--- a/test/GraphicalDisplayRenderer.cpp
+++ b/test/GraphicalDisplayRenderer.cpp
@@ -5,6 +5,12 @@
 
 class StubGraphicalDisplay : public GraphicalDisplayInterface {
   public:
+    uint8_t drawBoxCount = 0;
+    uint8_t drawXbmCount = 0;
+    uint8_t drawColorCount = 0;
+    uint8_t drawColors[4] = {0, 0, 0, 0};
+    uint8_t lastDrawBoxHeight = 0;
+
     void begin() override {}
     void clear() override {}
     void show() override {}
@@ -29,12 +35,31 @@ class StubGraphicalDisplay : public GraphicalDisplayInterface {
         }
         return static_cast<uint8_t>(len * 6);
     }
-    void setDrawColor(uint8_t) override {}
+    void setDrawColor(uint8_t color) override {
+        if (drawColorCount < 4) {
+            drawColors[drawColorCount] = color;
+        }
+        drawColorCount++;
+    }
     void clearBuffer() override {}
     void sendBuffer() override {}
-    void drawBox(uint8_t, uint8_t, uint8_t, uint8_t) override {}
+    void drawBox(uint8_t, uint8_t, uint8_t, uint8_t h) override {
+        drawBoxCount++;
+        lastDrawBoxHeight = h;
+    }
     void drawFrame(uint8_t, uint8_t, uint8_t, uint8_t) override {}
-    void drawXbm(uint8_t, uint8_t, uint8_t, uint8_t, const uint8_t*) override {}
+    void drawXbm(uint8_t, uint8_t, uint8_t, uint8_t, const uint8_t*) override {
+        drawXbmCount++;
+    }
+};
+
+class FocusableGraphicalDisplayRenderer : public GraphicalDisplayRenderer {
+  public:
+    using GraphicalDisplayRenderer::GraphicalDisplayRenderer;
+
+    void setFocusForTest(bool focused) {
+        hasFocus = focused;
+    }
 };
 
 unittest(graphical_renderer_exposes_value_selection_extension) {
@@ -47,6 +72,40 @@ unittest(graphical_renderer_exposes_value_selection_extension) {
     GraphicalValueSelectionRenderer* selection = static_cast<GraphicalValueSelectionRenderer*>(extension);
     selection->setValueSelection(1, 2);
     selection->clearValueSelection();
+}
+
+unittest(graphical_renderer_uses_tight_row_height) {
+    StubGraphicalDisplay display;
+    GraphicalDisplayRenderer renderer(&display);
+
+    renderer.drawItem("Label", NULL);
+
+    assertEqual(1, display.drawBoxCount);
+    assertEqual(8, display.lastDrawBoxHeight);
+}
+
+unittest(graphical_renderer_colors_indicators_when_focused) {
+    StubGraphicalDisplay display;
+    FocusableGraphicalDisplayRenderer renderer(&display);
+
+    renderer.setFocusForTest(true);
+    renderer.drawListIndicator();
+
+    assertEqual(2, display.drawColorCount);
+    assertEqual(0, display.drawColors[0]);
+    assertEqual(1, display.drawColors[1]);
+    assertEqual(1, display.drawXbmCount);
+
+    display.drawColorCount = 0;
+    display.drawXbmCount = 0;
+    display.drawBoxCount = 0;
+
+    renderer.drawSubMenuIndicator();
+
+    assertEqual(2, display.drawColorCount);
+    assertEqual(0, display.drawColors[0]);
+    assertEqual(1, display.drawColors[1]);
+    assertEqual(5, display.drawBoxCount);
 }
 
 unittest_main()


### PR DESCRIPTION
## Summary
- Tighten graphical renderer font metric and row-height handling to match the snapshot behavior.
- Render graphical list/submenu indicators with focus-aware draw colors.
- Add focused renderer tests for row height and indicator color behavior.

## Checks
- git diff --check
- pio run -e esp32

## Notes
- `pio run -e uno` currently fails because base `src/main.cpp` builds the graphical/U8g2 showcase and exceeds Uno memory/flash; this branch does not change `src/main.cpp`.
- `pio test -e uno` is blocked by missing `ArduinoUnitTests.h`/`Godmode.h` in the current PlatformIO test setup.