### PR TITLE
Harden graphical scrollbar rendering

### DIFF
--- a/src/renderer/GraphicalDisplayRenderer.cpp
+++ b/src/renderer/GraphicalDisplayRenderer.cpp
@@ -402,19 +402,26 @@ void GraphicalDisplayRenderer::drawScrollBar() {
         return;
     }
 
-    uint8_t x = gDisplay->getDisplayWidth() - scrollbarWidth;
-    uint8_t areaHeight = rows * rowHeight();
-    if (areaHeight > gDisplay->getDisplayHeight()) {
-        areaHeight = gDisplay->getDisplayHeight();
+    uint8_t displayWidth = gDisplay->getDisplayWidth();
+    uint16_t areaHeight16 = static_cast<uint16_t>(rows) * rowHeight();
+    if (areaHeight16 > gDisplay->getDisplayHeight()) {
+        areaHeight16 = gDisplay->getDisplayHeight();
     }
+    uint8_t areaHeight = static_cast<uint8_t>(areaHeight16);
+
+    uint8_t x = displayWidth - scrollbarWidth;
+
+    gDisplay->setDrawColor(0);
+    gDisplay->drawBox(x, 0, scrollbarWidth, areaHeight);
+    gDisplay->setDrawColor(1);
 
     uint8_t handleHeight = (static_cast<uint16_t>(rows) * areaHeight) / totalItems;
     if (handleHeight < 2) {
         handleHeight = 2;
     }
 
-    uint16_t scrollRange = totalItems - rows;
-    uint16_t trackRange = areaHeight - handleHeight;
-    uint8_t y = scrollRange == 0 ? 0 : (static_cast<uint16_t>(viewStart) * trackRange) / scrollRange;
+    uint16_t trackRange = areaHeight > handleHeight ? areaHeight - handleHeight : 0;
+    uint16_t scrollRange = totalItems > rows ? totalItems - rows : 1;
+    uint8_t y = (static_cast<uint16_t>(viewStart) * trackRange) / scrollRange;
     gDisplay->drawBox(x, y, scrollbarWidth, handleHeight);
 }

--- a/test/GraphicalDisplayRenderer.cpp
+++ b/test/GraphicalDisplayRenderer.cpp
@@ -10,6 +10,7 @@ class StubGraphicalDisplay : public GraphicalDisplayInterface {
     uint8_t drawColorCount = 0;
     uint8_t drawColors[4] = {0, 0, 0, 0};
     uint8_t lastDrawBoxHeight = 0;
+    uint8_t lastDrawBoxY = 0;
 
     void begin() override {}
     void clear() override {}
@@ -43,8 +44,9 @@ class StubGraphicalDisplay : public GraphicalDisplayInterface {
     }
     void clearBuffer() override {}
     void sendBuffer() override {}
-    void drawBox(uint8_t, uint8_t, uint8_t, uint8_t h) override {
+    void drawBox(uint8_t, uint8_t y, uint8_t, uint8_t h) override {
         drawBoxCount++;
+        lastDrawBoxY = y;
         lastDrawBoxHeight = h;
     }
     void drawFrame(uint8_t, uint8_t, uint8_t, uint8_t) override {}
@@ -82,6 +84,21 @@ unittest(graphical_renderer_uses_tight_row_height) {
 
     assertEqual(1, display.drawBoxCount);
     assertEqual(8, display.lastDrawBoxHeight);
+}
+
+unittest(graphical_renderer_clears_scrollbar_track_before_handle) {
+    StubGraphicalDisplay display;
+    GraphicalDisplayRenderer renderer(&display);
+
+    renderer.setViewportContext(0, 9);
+    renderer.drawItem("Label", NULL);
+
+    assertEqual(3, display.drawBoxCount);
+    assertEqual(0, display.drawColors[0]);
+    assertEqual(1, display.drawColors[1]);
+    assertEqual(0, display.drawColors[2]);
+    assertEqual(1, display.drawColors[3]);
+    assertEqual(0, display.lastDrawBoxY);
 }
 
 unittest(graphical_renderer_colors_indicators_when_focused) {


### PR DESCRIPTION
## Summary
- Clear the graphical scrollbar track before drawing the handle.
- Clamp scrollbar track and scroll range math to avoid underflow/division edge cases.
- Add focused renderer coverage for scrollbar track clearing.

## Checks
- git diff --check
- pio run -e esp32

## Notes
- Unrelated local `diagram.json`, `wokwi.toml`, `bin/`, and `docs/source/reference/samples/` changes were not included.