### PR TITLE
Fix renderer timeout hide debounce

### DIFF
--- a/src/renderer/MenuRenderer.cpp
+++ b/src/renderer/MenuRenderer.cpp
@@ -6,6 +6,7 @@ MenuRenderer::MenuRenderer(DisplayInterface* display, uint8_t maxCols, uint8_t m
 void MenuRenderer::begin() {
     display->begin();
     startTime = millis();
+    timeoutTriggered = false;
 }
 
 void MenuRenderer::moveCursor(uint8_t cursorCol, uint8_t cursorRow) {
@@ -15,6 +16,7 @@ void MenuRenderer::moveCursor(uint8_t cursorCol, uint8_t cursorRow) {
 
 void MenuRenderer::restartTimer() {
     this->startTime = millis();
+    timeoutTriggered = false;
     display->show();
 }
 

--- a/src/renderer/MenuRenderer.h
+++ b/src/renderer/MenuRenderer.h
@@ -38,6 +38,7 @@ class MenuRenderer {
     uint8_t cursorRow;
 
     unsigned long startTime = 0;
+    bool timeoutTriggered = false;
 
   public:
     /**
@@ -103,9 +104,10 @@ class MenuRenderer {
      * @brief Updates the display timer and hides the display if the timeout is reached.
      */
     virtual void updateTimer() {
-        if (millis() - startTime < DISPLAY_TIMEOUT) {
+        if (timeoutTriggered || millis() - startTime < DISPLAY_TIMEOUT) {
             return;
         }
+        timeoutTriggered = true;
         LOG(F("MenuRenderer::timeout"));
         display->hide();
     }


### PR DESCRIPTION
## Summary
- track whether the renderer timeout has already fired in the current timer cycle
- reset timeout state when the renderer begins or the timer restarts
- avoid repeated timeout hide/log calls after the display is already hidden

## Checks
- git diff --check
- pio run -e esp32

## Notes
- Stacked on feat/graphical-display after PR #416 merge
- Only src/renderer/MenuRenderer.cpp and src/renderer/MenuRenderer.h are included