### PR TITLE
Align input graphical selection docs

### DIFF
--- a/docs/source/overview/items/input-charset.rst
+++ b/docs/source/overview/items/input-charset.rst
@@ -29,10 +29,6 @@ The charset input item can be created using the following syntax:
 When the ``Pass`` menu item is selected, an input field will be displayed on the screen, allowing the user to enter a string value.
 The input value will be restricted to the characters specified in the charset.
 
-With graphical renderers that expose ``GraphicalValueSelectionRenderer``,
-character preview and selection are rendered through the value-area highlight,
-so charset cycling remains visible without relying on a text cursor blinker.
-
 .. image:: images/item-charset-input.gif
     :width: 400px
     :alt: Example of a charset input menu item

--- a/docs/source/overview/items/input.rst
+++ b/docs/source/overview/items/input.rst
@@ -24,18 +24,6 @@ You can create an input item by specifying the label and the default value:
 
 When the ``Name`` menu item is selected, an input field will be displayed on the screen, allowing the user to enter a string value.
 
-Graphical rendering
-~~~~~~~~~~~~~~~~~~~
-
-``ItemInput`` exposes optional graphical capabilities through
-``GraphicalMenuItem`` and reports its value width for right-aligned graphical
-layouts.
-
-When a renderer exposes ``GraphicalValueSelectionRenderer`` via
-``queryExtension()``, the input item highlights the active character instead of
-using a blinking character cursor. Character-display renderers continue to use
-the standard blinking cursor behavior.
-
 .. image:: images/item-input.gif
     :width: 400px
     :alt: Example of an input menu item

--- a/src/ItemInput.h
+++ b/src/ItemInput.h
@@ -146,9 +146,8 @@ class ItemInput : public MenuItem, public GraphicalMenuItem {
         if (selectionRenderer != NULL) {
             char* graphicalValue = value;
             char* insertionBuffer = NULL;
-            bool editing = MenuItem::isEditing();
 
-            if (editing) {
+            if (MenuItem::isEditing()) {
                 renderer->viewShift = 0;
                 uint8_t len = strlen(value);
                 uint8_t selectionStart = cursor > len ? len : cursor;
@@ -168,9 +167,7 @@ class ItemInput : public MenuItem, public GraphicalMenuItem {
             }
 
             renderer->drawItem(text, graphicalValue);
-            if (editing) {
-                selectionRenderer->clearValueSelection();
-            }
+            selectionRenderer->clearValueSelection();
 
             if (insertionBuffer != NULL) {
                 delete[] insertionBuffer;

--- a/src/ItemInputCharset.h
+++ b/src/ItemInputCharset.h
@@ -181,9 +181,6 @@ class ItemInputCharset : public ItemInput {
             renderer->viewShift = 0;
             uint8_t length = strlen(value);
 
-            // Update in place when cursor points to an existing character; when cursor
-            // is at the insertion position, render through a temporary preview buffer
-            // to avoid writing past the current string bounds.
             if (cursor < length) {
                 char original = value[cursor];
                 value[cursor] = charset[charsetPosition];

--- a/test/LcdMenu.cpp
+++ b/test/LcdMenu.cpp
@@ -133,6 +133,10 @@ class SelectionTrackingRenderer : public MenuRenderer, public GraphicalValueSele
     uint8_t selectionStart = 0;
     uint8_t selectionLength = 0;
     bool hasSelection = false;
+    uint8_t setValueSelectionCalls = 0;
+    uint8_t clearValueSelectionCalls = 0;
+    uint8_t lastSelectionStart = 0;
+    uint8_t lastSelectionLength = 0;
 
     SelectionTrackingRenderer() : MenuRenderer(&display, LCD_COLS, LCD_ROWS) {}
 
@@ -143,12 +147,16 @@ class SelectionTrackingRenderer : public MenuRenderer, public GraphicalValueSele
     uint8_t getEffectiveCols() const override { return maxCols; }
 
     void setValueSelection(uint8_t start, uint8_t length) override {
+        setValueSelectionCalls++;
+        lastSelectionStart = start;
+        lastSelectionLength = length;
         selectionStart = start;
         selectionLength = length;
         hasSelection = length > 0;
     }
 
     void clearValueSelection() override {
+        clearValueSelectionCalls++;
         selectionStart = 0;
         selectionLength = 0;
         hasSelection = false;
@@ -230,9 +238,19 @@ unittest(input_item_uses_graphical_selection_extension_in_edit_mode) {
     assertTrue(MenuItem::isEditing());
     assertEqual((uint8_t)3, item.cursor);
     assertEqual((uint8_t)0, renderer.blinkerDrawCalls);
+    assertEqual((uint8_t)1, renderer.setValueSelectionCalls);
+    assertEqual((uint8_t)1, renderer.clearValueSelectionCalls);
+    assertEqual((uint8_t)3, renderer.lastSelectionStart);
+    assertEqual((uint8_t)1, renderer.lastSelectionLength);
+    assertFalse(renderer.hasSelection);
 
     assertTrue(item.process(&menu, LEFT));
     assertEqual((uint8_t)2, item.cursor);
+    assertEqual((uint8_t)2, renderer.setValueSelectionCalls);
+    assertEqual((uint8_t)2, renderer.clearValueSelectionCalls);
+    assertEqual((uint8_t)2, renderer.lastSelectionStart);
+    assertEqual((uint8_t)1, renderer.lastSelectionLength);
+    assertFalse(renderer.hasSelection);
 
     assertTrue(item.process(&menu, BACK));
     assertFalse(MenuItem::isEditing());


### PR DESCRIPTION
## Summary
- always clear graphical value selection after input item rendering
- remove stale implementation-specific input graphical docs/comments
- strengthen LcdMenu input graphical selection coverage to verify selection set/clear behavior

## Checks
- git diff --check
- clang-format --dry-run --Werror src/ItemInput.h src/ItemInputCharset.h test/LcdMenu.cpp
- pio run -e esp32
- make html (from docs/; succeeded with existing unrelated warnings)

## Notes
- focused pio test path remains blocked locally by missing ArduinoUnitTests.h / Godmode.h in the current PlatformIO test harness
- intentionally skipped snapshot deletions in test/ItemValue.cpp as low-value/unrelated to this bundle
- only scoped input headers, item docs pages, and test/LcdMenu.cpp are included